### PR TITLE
Add AgentRank skill to community registry

### DIFF
--- a/sources/community.json
+++ b/sources/community.json
@@ -2,154 +2,2051 @@
   "name": "Community Skills",
   "description": "Community-contributed Claude Code skills from GitHub ecosystem",
   "skills": [
-    {"name": "superpowers", "repo": "obra/superpowers", "path": "", "description": "20+ battle-tested skills for Claude Code including TDD, debugging, and collaboration patterns", "category": "development", "tags": ["tdd", "debugging", "collaboration", "productivity"], "stars": 0, "featured": true},
-    {"name": "test-driven-development", "repo": "obra/superpowers", "path": "test-driven-development", "description": "TDD discipline with RED-GREEN-REFACTOR cycle. Ensures tests genuinely verify behavior", "category": "testing", "tags": ["tdd", "testing", "red-green-refactor"], "stars": 0, "featured": true},
-    {"name": "systematic-debugging", "repo": "obra/superpowers", "path": "systematic-debugging", "description": "Four-phase debugging framework for any technical issue. Prevents random fix attempts", "category": "development", "tags": ["debugging", "troubleshooting", "methodology"], "stars": 0, "featured": true},
-    {"name": "brainstorming", "repo": "obra/superpowers", "path": "brainstorming", "description": "Collaborative design refinement through Socratic dialogue for exploring ideas", "category": "productivity", "tags": ["brainstorming", "design", "collaboration", "ideation"], "stars": 0},
-    {"name": "writing-plans", "repo": "obra/superpowers", "path": "writing-plans", "description": "Creates detailed implementation plans with bite-sized tasks", "category": "productivity", "tags": ["planning", "documentation", "writing"], "stars": 0},
-    {"name": "executing-plans", "repo": "obra/superpowers", "path": "executing-plans", "description": "Batch execution with human checkpoints for implementation", "category": "productivity", "tags": ["execution", "workflow", "automation"], "stars": 0},
-    {"name": "dispatching-parallel-agents", "repo": "obra/superpowers", "path": "dispatching-parallel-agents", "description": "Enables concurrent subagent workflows for parallel processing", "category": "development", "tags": ["subagents", "parallel", "orchestration"], "stars": 0},
-    {"name": "requesting-code-review", "repo": "obra/superpowers", "path": "requesting-code-review", "description": "Pre-review checklist and validation before code review", "category": "development", "tags": ["code-review", "checklist", "validation"], "stars": 0},
-    {"name": "receiving-code-review", "repo": "obra/superpowers", "path": "receiving-code-review", "description": "Handles feedback incorporation from code reviews", "category": "development", "tags": ["code-review", "feedback", "improvement"], "stars": 0},
-    {"name": "using-git-worktrees", "repo": "obra/superpowers", "path": "using-git-worktrees", "description": "Manages parallel development branches with git worktrees", "category": "development", "tags": ["git", "worktrees", "branching", "parallel"], "stars": 0, "featured": true},
-    {"name": "finishing-a-development-branch", "repo": "obra/superpowers", "path": "finishing-a-development-branch", "description": "Merge/PR decision workflow for completing branches", "category": "development", "tags": ["git", "merge", "pr", "workflow"], "stars": 0},
-    {"name": "subagent-driven-development", "repo": "obra/superpowers", "path": "subagent-driven-development", "description": "Two-stage review process - spec compliance then code quality", "category": "development", "tags": ["subagents", "review", "quality"], "stars": 0, "featured": true},
-    {"name": "verification-before-completion", "repo": "obra/superpowers", "path": "verification-before-completion", "description": "Confirms fixes are effective before marking complete", "category": "development", "tags": ["verification", "quality", "testing"], "stars": 0},
-    {"name": "writing-skills", "repo": "obra/superpowers", "path": "writing-skills", "description": "Guidance for creating new Claude Code skills following best practices", "category": "development", "tags": ["skills", "creation", "meta"], "stars": 0},
-    {"name": "elegant-architecture", "repo": "obra/superpowers", "path": "elegant-architecture", "description": "Clean architecture design with strict 200-line file limits", "category": "development", "tags": ["architecture", "clean-code", "modular"], "stars": 0},
-    {"name": "comprehensive-testing", "repo": "obra/superpowers", "path": "comprehensive-testing", "description": "Complete testing strategy covering unit, integration, E2E", "category": "testing", "tags": ["testing", "unit-tests", "integration", "e2e"], "stars": 0},
-    {"name": "ln-100-documents-pipeline", "repo": "levnikolaevich/claude-code-skills", "path": "skills/ln-100-documents-pipeline", "description": "Top orchestrator for complete documentation with Linear MCP", "category": "documents", "tags": ["documentation", "orchestrator", "linear", "agile"], "stars": 0},
-    {"name": "ln-200-scope-decomposer", "repo": "levnikolaevich/claude-code-skills", "path": "skills/ln-200-scope-decomposer", "description": "Full decomposition orchestrator for Agile planning", "category": "productivity", "tags": ["agile", "planning", "decomposition", "linear"], "stars": 0},
-    {"name": "ln-210-epic-coordinator", "repo": "levnikolaevich/claude-code-skills", "path": "skills/ln-210-epic-coordinator", "description": "Epic creation and management for Agile workflows", "category": "productivity", "tags": ["agile", "epic", "planning", "linear"], "stars": 0},
-    {"name": "ln-220-story-coordinator", "repo": "levnikolaevich/claude-code-skills", "path": "skills/ln-220-story-coordinator", "description": "Story operations coordinator for Agile teams", "category": "productivity", "tags": ["agile", "stories", "planning", "linear"], "stars": 0},
-    {"name": "ln-300-task-coordinator", "repo": "levnikolaevich/claude-code-skills", "path": "skills/ln-300-task-coordinator", "description": "Task decomposition coordinator for development", "category": "productivity", "tags": ["agile", "tasks", "decomposition", "linear"], "stars": 0},
-    {"name": "ln-400-story-pipeline", "repo": "levnikolaevich/claude-code-skills", "path": "skills/ln-400-story-pipeline", "description": "Complete story workflow orchestrator for Agile", "category": "development", "tags": ["agile", "workflow", "pipeline", "linear"], "stars": 0},
-    {"name": "ln-500-story-quality-gate", "repo": "levnikolaevich/claude-code-skills", "path": "skills/ln-500-story-quality-gate", "description": "Story quality validation coordinator with gates", "category": "testing", "tags": ["quality", "validation", "gates", "linear"], "stars": 0},
-    {"name": "ln-501-code-quality-checker", "repo": "levnikolaevich/claude-code-skills", "path": "skills/ln-501-code-quality-checker", "description": "Code quality analysis and linting", "category": "development", "tags": ["quality", "linting", "analysis", "linear"], "stars": 0},
-    {"name": "ln-620-codebase-auditor", "repo": "levnikolaevich/claude-code-skills", "path": "skills/ln-620-codebase-auditor", "description": "Comprehensive codebase audit coordinator", "category": "development", "tags": ["audit", "codebase", "analysis", "linear"], "stars": 0},
-    {"name": "ln-621-security-auditor", "repo": "levnikolaevich/claude-code-skills", "path": "skills/ln-621-security-auditor", "description": "Security vulnerability scanning for codebases", "category": "development", "tags": ["security", "audit", "vulnerabilities", "linear"], "stars": 0},
-    {"name": "ln-630-test-auditor", "repo": "levnikolaevich/claude-code-skills", "path": "skills/ln-630-test-auditor", "description": "Test suite quality coordinator and analysis", "category": "testing", "tags": ["testing", "audit", "quality", "linear"], "stars": 0},
-    {"name": "claudekit-backend-development", "repo": "mrgoonie/claudekit-skills", "path": "skills/backend-development", "description": "Build robust backend systems with Node.js, Python, Go, Rust", "category": "development", "tags": ["backend", "nodejs", "python", "go", "rust"], "stars": 0, "featured": true},
-    {"name": "claudekit-frontend-development", "repo": "mrgoonie/claudekit-skills", "path": "skills/frontend-development", "description": "React/TypeScript patterns with Suspense, lazy loading, TanStack Router", "category": "development", "tags": ["frontend", "react", "typescript", "tanstack"], "stars": 0},
-    {"name": "claudekit-web-frameworks", "repo": "mrgoonie/claudekit-skills", "path": "skills/web-frameworks", "description": "Build full-stack apps with Next.js, Turborepo, RemixIcon", "category": "development", "tags": ["nextjs", "turborepo", "monorepo", "fullstack"], "stars": 0},
-    {"name": "claudekit-ui-styling", "repo": "mrgoonie/claudekit-skills", "path": "skills/ui-styling", "description": "Create accessible UIs with shadcn/ui, Tailwind CSS", "category": "design", "tags": ["shadcn", "tailwind", "ui", "accessibility"], "stars": 0},
-    {"name": "claudekit-aesthetic", "repo": "mrgoonie/claudekit-skills", "path": "skills/aesthetic", "description": "Create aesthetically beautiful interfaces with visual hierarchy", "category": "design", "tags": ["design", "ui", "aesthetics", "visual"], "stars": 0},
-    {"name": "claudekit-chrome-devtools", "repo": "mrgoonie/claudekit-skills", "path": "skills/chrome-devtools", "description": "Browser automation with Puppeteer for screenshots, network monitoring", "category": "testing", "tags": ["puppeteer", "automation", "browser", "devtools"], "stars": 0},
-    {"name": "claudekit-devops", "repo": "mrgoonie/claudekit-skills", "path": "skills/devops", "description": "Deploy on Cloudflare, Docker, GCP with serverless and CI/CD", "category": "development", "tags": ["devops", "cloudflare", "docker", "gcp", "ci-cd"], "stars": 0},
-    {"name": "claudekit-databases", "repo": "mrgoonie/claudekit-skills", "path": "skills/databases", "description": "MongoDB and PostgreSQL - schema design, queries, migrations", "category": "data", "tags": ["mongodb", "postgresql", "database", "schema"], "stars": 0},
-    {"name": "claudekit-mcp-builder", "repo": "mrgoonie/claudekit-skills", "path": "skills/mcp-builder", "description": "Build MCP servers in Python (FastMCP) or TypeScript", "category": "development", "tags": ["mcp", "fastmcp", "typescript", "python"], "stars": 0},
-    {"name": "claudekit-mcp-management", "repo": "mrgoonie/claudekit-skills", "path": "skills/mcp-management", "description": "Manage MCP servers - discover, analyze, execute tools", "category": "development", "tags": ["mcp", "management", "tools", "servers"], "stars": 0},
-    {"name": "claudekit-repomix", "repo": "mrgoonie/claudekit-skills", "path": "skills/repomix", "description": "Package repositories into single AI-friendly files", "category": "productivity", "tags": ["repomix", "packaging", "ai", "analysis"], "stars": 0},
-    {"name": "claudekit-media-processing", "repo": "mrgoonie/claudekit-skills", "path": "skills/media-processing", "description": "Process multimedia with FFmpeg and ImageMagick", "category": "productivity", "tags": ["ffmpeg", "imagemagick", "media", "processing"], "stars": 0},
-    {"name": "claudekit-docs-seeker", "repo": "mrgoonie/claudekit-skills", "path": "skills/docs-seeker", "description": "Intelligent documentation discovery using llms.txt standard", "category": "productivity", "tags": ["documentation", "discovery", "llms-txt"], "stars": 0},
-    {"name": "claudekit-code-review", "repo": "mrgoonie/claudekit-skills", "path": "skills/code-review", "description": "Review code feedback with verification before claims", "category": "development", "tags": ["code-review", "verification", "quality"], "stars": 0},
-    {"name": "claudekit-defense-in-depth", "repo": "mrgoonie/claudekit-skills", "path": "skills/debugging/defense-in-depth", "description": "Validate at every data layer with entry validation", "category": "development", "tags": ["debugging", "validation", "security"], "stars": 0},
-    {"name": "claudekit-root-cause-tracing", "repo": "mrgoonie/claudekit-skills", "path": "skills/debugging/root-cause-tracing", "description": "Trace bugs backward through call stacks to find triggers", "category": "development", "tags": ["debugging", "root-cause", "tracing"], "stars": 0},
-    {"name": "claudekit-systematic-debugging", "repo": "mrgoonie/claudekit-skills", "path": "skills/debugging/systematic-debugging", "description": "Four-phase framework for root cause investigation", "category": "development", "tags": ["debugging", "systematic", "methodology"], "stars": 0},
-    {"name": "claudekit-docx", "repo": "mrgoonie/claudekit-skills", "path": "skills/document-skills/docx", "description": "Create and edit Word documents with tracked changes", "category": "documents", "tags": ["docx", "word", "documents"], "stars": 0},
-    {"name": "claudekit-pdf", "repo": "mrgoonie/claudekit-skills", "path": "skills/document-skills/pdf", "description": "Extract text/tables, create PDFs, merge/split documents", "category": "documents", "tags": ["pdf", "documents", "extraction"], "stars": 0},
-    {"name": "claudekit-pptx", "repo": "mrgoonie/claudekit-skills", "path": "skills/document-skills/pptx", "description": "Create PowerPoint presentations with layouts and animations", "category": "documents", "tags": ["pptx", "powerpoint", "presentations"], "stars": 0},
-    {"name": "claudekit-xlsx", "repo": "mrgoonie/claudekit-skills", "path": "skills/document-skills/xlsx", "description": "Build spreadsheets with formulas and financial modeling", "category": "documents", "tags": ["xlsx", "excel", "spreadsheets"], "stars": 0},
-    {"name": "claudekit-shopify", "repo": "mrgoonie/claudekit-skills", "path": "skills/shopify", "description": "Build Shopify apps and themes with GraphQL/REST APIs", "category": "development", "tags": ["shopify", "ecommerce", "graphql", "liquid"], "stars": 0},
-    {"name": "claudekit-collision-zone-thinking", "repo": "mrgoonie/claudekit-skills", "path": "skills/problem-solving/collision-zone-thinking", "description": "Force unrelated concepts together to discover emergent properties", "category": "productivity", "tags": ["problem-solving", "creativity", "thinking"], "stars": 0},
-    {"name": "claudekit-inversion-exercise", "repo": "mrgoonie/claudekit-skills", "path": "skills/problem-solving/inversion-exercise", "description": "Flip core assumptions to reveal hidden constraints", "category": "productivity", "tags": ["problem-solving", "inversion", "thinking"], "stars": 0},
-    {"name": "claudekit-meta-pattern-recognition", "repo": "mrgoonie/claudekit-skills", "path": "skills/problem-solving/meta-pattern-recognition", "description": "Spot patterns across 3+ domains to extract universal principles", "category": "productivity", "tags": ["problem-solving", "patterns", "thinking"], "stars": 0},
-    {"name": "claudekit-sequential-thinking", "repo": "mrgoonie/claudekit-skills", "path": "skills/sequential-thinking", "description": "Systematic step-by-step reasoning for complex problems", "category": "productivity", "tags": ["reasoning", "thinking", "systematic"], "stars": 0},
-    {"name": "claudekit-skill-creator", "repo": "mrgoonie/claudekit-skills", "path": "skills/skill-creator", "description": "Guide for creating effective Claude Code skills", "category": "development", "tags": ["skills", "creation", "meta"], "stars": 0},
-    {"name": "claudekit-better-auth", "repo": "mrgoonie/claudekit-skills", "path": "skills/better-auth", "description": "TypeScript auth framework with OAuth, 2FA, passkeys, multi-tenancy", "category": "development", "tags": ["auth", "oauth", "2fa", "passkeys"], "stars": 0},
-    {"name": "claudekit-google-adk-python", "repo": "mrgoonie/claudekit-skills", "path": "skills/google-adk-python", "description": "Google Agent Development Kit for AI agents with multi-agent orchestration", "category": "data", "tags": ["google", "adk", "agents", "ai"], "stars": 0},
-    {"name": "claudekit-ai-multimodal", "repo": "mrgoonie/claudekit-skills", "path": "skills/ai-multimodal", "description": "Process multimedia using Google Gemini API - audio, image, video", "category": "data", "tags": ["gemini", "multimodal", "audio", "video"], "stars": 0},
-    {"name": "n8n-expression-syntax", "repo": "czlonkowski/n8n-skills", "path": "skills/n8n-expression-syntax", "description": "n8n expression syntax with $json, $node, $now, $env variables", "category": "development", "tags": ["n8n", "automation", "expressions", "workflow"], "stars": 0},
-    {"name": "n8n-mcp-tools-expert", "repo": "czlonkowski/n8n-skills", "path": "skills/n8n-mcp-tools-expert", "description": "n8n-mcp MCP tools, validation profiles, nodeType formats", "category": "development", "tags": ["n8n", "mcp", "automation", "tools"], "stars": 0, "featured": true},
-    {"name": "n8n-workflow-patterns", "repo": "czlonkowski/n8n-skills", "path": "skills/n8n-workflow-patterns", "description": "5 proven architectural patterns for n8n workflows", "category": "development", "tags": ["n8n", "patterns", "architecture", "workflow"], "stars": 0},
-    {"name": "n8n-validation-expert", "repo": "czlonkowski/n8n-skills", "path": "skills/n8n-validation-expert", "description": "Interpret validation errors and troubleshoot n8n workflows", "category": "development", "tags": ["n8n", "validation", "troubleshooting"], "stars": 0},
-    {"name": "n8n-node-configuration", "repo": "czlonkowski/n8n-skills", "path": "skills/n8n-node-configuration", "description": "Operation-aware n8n node configuration guidance", "category": "development", "tags": ["n8n", "configuration", "nodes"], "stars": 0},
-    {"name": "n8n-code-javascript", "repo": "czlonkowski/n8n-skills", "path": "skills/n8n-code-javascript", "description": "JavaScript coding in n8n Code nodes with data access patterns", "category": "development", "tags": ["n8n", "javascript", "code"], "stars": 0},
-    {"name": "n8n-code-python", "repo": "czlonkowski/n8n-skills", "path": "skills/n8n-code-python", "description": "Python coding in n8n Code nodes with standard library usage", "category": "development", "tags": ["n8n", "python", "code"], "stars": 0},
-    {"name": "ios-simulator-skill", "repo": "conorluddy/ios-simulator-skill", "path": "", "description": "iOS Simulator automation for testing with semantic navigation and Xcode integration", "category": "testing", "tags": ["ios", "simulator", "xcode", "testing", "mobile"], "stars": 0, "featured": true},
-    {"name": "playwright-skill", "repo": "lackeyjb/playwright-skill", "path": "", "description": "Browser automation with Playwright - Claude writes and executes custom scripts", "category": "testing", "tags": ["playwright", "browser", "automation", "testing"], "stars": 0, "featured": true},
-    {"name": "claude-d3js-skill", "repo": "chrisvoncsefalvay/claude-d3js-skill", "path": "", "description": "D3.js visualization skill for creating interactive data visualizations", "category": "data", "tags": ["d3", "visualization", "charts", "javascript"], "stars": 0},
-    {"name": "ffuf-web-fuzzing", "repo": "jthack/ffuf_claude_skill", "path": "", "description": "Web fuzzing with ffuf for security testing - directories, files, subdomains", "category": "development", "tags": ["security", "fuzzing", "ffuf", "pentesting"], "stars": 0},
-    {"name": "web-asset-generator", "repo": "alonw0/web-asset-generator", "path": "", "description": "Generate favicons, app icons, social media images with WCAG compliance", "category": "design", "tags": ["favicon", "icons", "pwa", "assets"], "stars": 0},
-    {"name": "codex-skill", "repo": "feiskyer/claude-code-settings", "path": "plugins/codex-skill", "description": "Non-interactive automation mode using OpenAI Codex", "category": "development", "tags": ["codex", "automation", "openai"], "stars": 0},
-    {"name": "autonomous-skill", "repo": "feiskyer/claude-code-settings", "path": "plugins/autonomous-skill", "description": "Execute complex long-running tasks across multiple sessions", "category": "development", "tags": ["autonomous", "sessions", "long-running"], "stars": 0},
-    {"name": "nanobanana-skill", "repo": "feiskyer/claude-code-settings", "path": "plugins/nanobanana-skill", "description": "Generate or edit images using Google Gemini API", "category": "design", "tags": ["gemini", "images", "generation"], "stars": 0},
-    {"name": "youtube-transcribe-skill", "repo": "feiskyer/claude-code-settings", "path": "plugins/youtube-transcribe-skill", "description": "Extract subtitles and transcripts from YouTube videos", "category": "productivity", "tags": ["youtube", "transcription", "subtitles"], "stars": 0},
-    {"name": "kiro-skill", "repo": "feiskyer/claude-code-settings", "path": "skills/kiro-skill", "description": "Interactive feature development: Requirements -> Design -> Tasks -> Execute", "category": "development", "tags": ["workflow", "feature", "development"], "stars": 0},
-    {"name": "spec-kit-skill", "repo": "feiskyer/claude-code-settings", "path": "skills/spec-kit-skill", "description": "GitHub Spec-Kit integration for spec-driven development", "category": "development", "tags": ["spec", "driven", "github"], "stars": 0},
-    {"name": "typo3-documentation", "repo": "netresearch/claude-code-marketplace", "path": "skills/typo3-documentation", "description": "Create TYPO3 extension documentation", "category": "documents", "tags": ["typo3", "documentation", "cms"], "stars": 0},
-    {"name": "typo3-testing", "repo": "netresearch/claude-code-marketplace", "path": "skills/typo3-testing", "description": "Manage TYPO3 extension tests", "category": "testing", "tags": ["typo3", "testing", "cms"], "stars": 0},
-    {"name": "typo3-ddev-setup", "repo": "netresearch/claude-code-marketplace", "path": "skills/typo3-ddev-setup", "description": "Automate DDEV environment setup for TYPO3", "category": "development", "tags": ["typo3", "ddev", "environment"], "stars": 0},
-    {"name": "typo3-extension-upgrade", "repo": "netresearch/claude-code-marketplace", "path": "skills/typo3-extension-upgrade", "description": "Systematic extension upgrades to newer TYPO3 LTS versions", "category": "development", "tags": ["typo3", "upgrade", "lts"], "stars": 0},
-    {"name": "jira-integration", "repo": "netresearch/claude-code-marketplace", "path": "skills/jira-integration", "description": "Jira API operations, wiki markup, and workflow automation", "category": "productivity", "tags": ["jira", "api", "workflow", "automation"], "stars": 0},
-    {"name": "git-workflow", "repo": "netresearch/claude-code-marketplace", "path": "skills/git-workflow", "description": "Git branching strategies and Conventional Commits", "category": "development", "tags": ["git", "branching", "conventional-commits"], "stars": 0},
-    {"name": "github-project", "repo": "netresearch/claude-code-marketplace", "path": "skills/github-project", "description": "GitHub repository setup and platform features", "category": "development", "tags": ["github", "repository", "setup"], "stars": 0},
-    {"name": "enterprise-readiness", "repo": "netresearch/claude-code-marketplace", "path": "skills/enterprise-readiness", "description": "OpenSSF security assessment and compliance", "category": "development", "tags": ["openssf", "security", "compliance", "enterprise"], "stars": 0},
-    {"name": "security-audit-php", "repo": "netresearch/claude-code-marketplace", "path": "skills/security-audit", "description": "OWASP security audit patterns for PHP applications", "category": "development", "tags": ["security", "owasp", "php", "audit"], "stars": 0},
-    {"name": "php-modernization", "repo": "netresearch/claude-code-marketplace", "path": "skills/php-modernization", "description": "PHP 8.x modernization and type safety", "category": "development", "tags": ["php", "modernization", "php8", "types"], "stars": 0},
-    {"name": "go-development", "repo": "netresearch/claude-code-marketplace", "path": "skills/go-development", "description": "Production-grade Go development patterns", "category": "development", "tags": ["go", "golang", "patterns"], "stars": 0},
-    {"name": "agents-md-generator", "repo": "netresearch/claude-code-marketplace", "path": "skills/agents-md-generator", "description": "Generate AGENTS.md documentation for repositories", "category": "documents", "tags": ["agents", "documentation", "generator"], "stars": 0},
-    {"name": "cli-tools-installer", "repo": "netresearch/claude-code-marketplace", "path": "skills/cli-tools", "description": "Auto-install missing CLI tools as needed", "category": "development", "tags": ["cli", "tools", "installer"], "stars": 0},
-    {"name": "coach-skill", "repo": "netresearch/claude-code-marketplace", "path": "skills/coach", "description": "Self-improving learning system with friction detection", "category": "productivity", "tags": ["learning", "coaching", "improvement"], "stars": 0},
-    {"name": "claude-scientific-skills", "repo": "K-Dense-AI/claude-scientific-skills", "path": "", "description": "125+ scientific skills for bioinformatics, cheminformatics, clinical research, ML", "category": "data", "tags": ["science", "research", "bioinformatics", "ml"], "stars": 0, "featured": true},
-    {"name": "skill-seekers", "repo": "yusufkaraaslan/Skill_Seekers", "path": "", "description": "Convert docs, repos, PDFs into Claude Skills with conflict detection", "category": "productivity", "tags": ["converter", "skills", "documentation"], "stars": 0},
-    {"name": "claude-mem", "repo": "thedotmack/claude-mem", "path": "", "description": "Session activity capture with AI compression for context injection", "category": "productivity", "tags": ["memory", "context", "sessions"], "stars": 0},
-    {"name": "agents-orchestration", "repo": "wshobson/agents", "path": "", "description": "Intelligent automation and multi-agent orchestration for Claude Code", "category": "development", "tags": ["agents", "orchestration", "automation"], "stars": 0},
-    {"name": "coderunner-sandbox", "repo": "instavm/coderunner", "path": "", "description": "Secure local sandbox to run LLM-generated code using Apple containers", "category": "development", "tags": ["sandbox", "security", "apple", "containers"], "stars": 0},
-    {"name": "ai-research-skills", "repo": "zechenzhangAGI/AI-research-SKILLs", "path": "", "description": "Library of AI research and engineering skills for multiple AI models", "category": "data", "tags": ["ai", "research", "engineering"], "stars": 0},
-    {"name": "claude-codepro", "repo": "maxritter/claude-codepro", "path": "", "description": "Professional dev environment with spec-driven workflow and cross-session memory", "category": "development", "tags": ["professional", "workflow", "memory"], "stars": 0},
-    {"name": "pg-aiguide", "repo": "timescale/pg-aiguide", "path": "", "description": "MCP server providing PostgreSQL skills and documentation", "category": "data", "tags": ["postgresql", "mcp", "database"], "stars": 0},
-    {"name": "claudepro-directory", "repo": "JSONbored/claudepro-directory", "path": "", "description": "Searchable collection of pre-built configurations and MCP servers", "category": "productivity", "tags": ["directory", "configurations", "mcp"], "stars": 0},
-    {"name": "outline-driven-development", "repo": "OutlineDriven/outline-driven-development", "path": "", "description": "Beyond specs or vibes - AST analysis and Modern CLI Tools", "category": "development", "tags": ["outline", "ast", "cli"], "stars": 0},
-    {"name": "rails-dev-skills", "repo": "alec-c4/claude-skills-rails-dev", "path": "", "description": "Ruby on Rails development skills with RSpec testing", "category": "development", "tags": ["rails", "ruby", "rspec"], "stars": 0},
-    {"name": "developer-kit-java", "repo": "giuseppe-trisciuoglio/developer-kit", "path": "", "description": "Java/Spring Boot patterns starter toolkit for skills and agents", "category": "development", "tags": ["java", "spring-boot", "patterns"], "stars": 0},
-    {"name": "universal-dev-skills", "repo": "AsiaOstrich/universal-dev-skills", "path": "", "description": "Skills from universal documentation standards for dev best practices", "category": "development", "tags": ["standards", "best-practices", "universal"], "stars": 0},
-    {"name": "grok-skill", "repo": "mikedemarais/grok-skill", "path": "", "description": "Route Twitter/X prompts to Grok-4 Live Search", "category": "productivity", "tags": ["grok", "twitter", "search"], "stars": 0},
-    {"name": "claude-code-toolbox", "repo": "alex-feel/claude-code-toolbox", "path": "", "description": "Automated environment configuration with cross-platform setup", "category": "development", "tags": ["toolbox", "environment", "configuration"], "stars": 0},
-    {"name": "continuous-claude", "repo": "parcadei/Continuous-Claude", "path": "", "description": "Toolkit preserving session state using hooks and file-based handoffs", "category": "development", "tags": ["sessions", "state", "handoffs"], "stars": 0},
-    {"name": "odin-claude-plugin", "repo": "OutlineDriven/odin-claude-plugin", "path": "", "description": "Outline-driven development as a Claude Code plugin", "category": "development", "tags": ["outline", "plugin", "development"], "stars": 0},
-    {"name": "ubrowser", "repo": "Lulzx/ubrowser", "path": "", "description": "Browser automation optimized for speed and cost efficiency", "category": "testing", "tags": ["browser", "automation", "speed"], "stars": 0},
-    {"name": "claude-code-artifacts", "repo": "alex-feel/claude-code-artifacts-public", "path": "", "description": "Pre-built library with subagents, hooks, commands, system prompts", "category": "development", "tags": ["artifacts", "subagents", "hooks"], "stars": 0},
-    {"name": "claude-insane-guide", "repo": "ThibautMelen/claude-insane-guide", "path": "", "description": "Comprehensive French-language guide covering Memory, Commands, MCP", "category": "productivity", "tags": ["guide", "french", "tutorial"], "stars": 0},
-    {"name": "clone-website", "repo": "julianromli/ai-skills", "path": "clone-website", "description": "Clone and recreate website designs with modern frameworks", "category": "development", "tags": ["web", "clone", "frontend", "design"], "stars": 0},
-    {"name": "frontend-design", "repo": "julianromli/ai-skills", "path": "frontend-design", "description": "Create distinctive, production-grade frontend interfaces", "category": "design", "tags": ["frontend", "ui", "design", "web"], "stars": 0},
-    {"name": "frontend-ui-animator", "repo": "julianromli/ai-skills", "path": "frontend-ui-animator", "description": "Add smooth animations and transitions to UI components", "category": "design", "tags": ["animation", "ui", "frontend", "motion"], "stars": 0},
-    {"name": "backend-dev", "repo": "julianromli/ai-skills", "path": "backend-dev", "description": "Backend development best practices and patterns", "category": "development", "tags": ["backend", "api", "server", "database"], "stars": 0},
-    {"name": "bug-fixer", "repo": "julianromli/ai-skills", "path": "bug-fixer", "description": "Systematic approach to identifying and fixing bugs", "category": "development", "tags": ["debugging", "bugfix", "troubleshooting"], "stars": 0},
-    {"name": "code-reviewer", "repo": "julianromli/ai-skills", "path": "code-reviewer", "description": "Comprehensive code review with security and performance analysis", "category": "development", "tags": ["code-review", "quality", "security", "best-practices"], "stars": 0},
-    {"name": "documentation-creator", "repo": "julianromli/ai-skills", "path": "documentation-creator", "description": "Generate comprehensive documentation for codebases", "category": "documents", "tags": ["documentation", "readme", "api-docs", "technical-writing"], "stars": 0},
-    {"name": "commit-msg", "repo": "julianromli/ai-skills", "path": "commit-msg", "description": "Generate meaningful, conventional commit messages", "category": "development", "tags": ["git", "commits", "conventional-commits"], "stars": 0},
-    {"name": "file-organizer", "repo": "julianromli/ai-skills", "path": "file-organizer", "description": "Organize and structure project files intelligently", "category": "productivity", "tags": ["organization", "files", "structure", "cleanup"], "stars": 0},
-    {"name": "perf-optimizer", "repo": "julianromli/ai-skills", "path": "perf-optimizer", "description": "Performance optimization for web applications", "category": "development", "tags": ["performance", "optimization", "speed", "profiling"], "stars": 0},
-    {"name": "prompter", "repo": "julianromli/ai-skills", "path": "prompter", "description": "Craft effective prompts for AI interactions", "category": "productivity", "tags": ["prompts", "ai", "prompt-engineering"], "stars": 0},
-    {"name": "refactorer", "repo": "julianromli/ai-skills", "path": "refactorer", "description": "Intelligent code refactoring with safety checks", "category": "development", "tags": ["refactoring", "clean-code", "improvement"], "stars": 0},
-    {"name": "security-auditor", "repo": "julianromli/ai-skills", "path": "security-auditor", "description": "Security vulnerability scanning and remediation", "category": "development", "tags": ["security", "audit", "vulnerabilities", "owasp"], "stars": 0},
-    {"name": "unit-tester", "repo": "julianromli/ai-skills", "path": "unit-tester", "description": "Generate comprehensive unit tests for your code", "category": "testing", "tags": ["unit-tests", "testing", "coverage"], "stars": 0},
-    {"name": "marketing-brand-builder", "repo": "alirezarezvani/claude-skills", "path": "marketing/brand-builder", "description": "Build and develop brand identity and guidelines", "category": "marketing", "tags": ["brand", "marketing", "identity", "guidelines"], "stars": 0},
-    {"name": "marketing-content-creator", "repo": "alirezarezvani/claude-skills", "path": "marketing/content-creator", "description": "Create engaging marketing content across channels", "category": "marketing", "tags": ["content", "marketing", "copywriting", "social-media"], "stars": 0},
-    {"name": "marketing-seo-optimizer", "repo": "alirezarezvani/claude-skills", "path": "marketing/seo-optimizer", "description": "Optimize content and websites for search engines", "category": "marketing", "tags": ["seo", "search", "optimization", "keywords"], "stars": 0},
-    {"name": "marketing-campaign-planner", "repo": "alirezarezvani/claude-skills", "path": "marketing/campaign-planner", "description": "Plan and execute marketing campaigns", "category": "marketing", "tags": ["campaigns", "marketing", "planning", "strategy"], "stars": 0},
-    {"name": "marketing-analytics-reporter", "repo": "alirezarezvani/claude-skills", "path": "marketing/analytics-reporter", "description": "Analyze marketing performance and create reports", "category": "marketing", "tags": ["analytics", "reports", "metrics", "kpis"], "stars": 0},
-    {"name": "engineering-code-architect", "repo": "alirezarezvani/claude-skills", "path": "engineering/code-architect", "description": "Design scalable software architecture", "category": "development", "tags": ["architecture", "design", "scalability", "patterns"], "stars": 0},
-    {"name": "engineering-api-designer", "repo": "alirezarezvani/claude-skills", "path": "engineering/api-designer", "description": "Design RESTful and GraphQL APIs with best practices", "category": "development", "tags": ["api", "rest", "graphql", "design"], "stars": 0},
-    {"name": "engineering-database-modeler", "repo": "alirezarezvani/claude-skills", "path": "engineering/database-modeler", "description": "Design efficient database schemas and models", "category": "data", "tags": ["database", "schema", "modeling", "sql"], "stars": 0},
-    {"name": "engineering-devops-assistant", "repo": "alirezarezvani/claude-skills", "path": "engineering/devops-assistant", "description": "CI/CD pipelines, infrastructure, and deployment automation", "category": "development", "tags": ["devops", "ci-cd", "infrastructure", "automation"], "stars": 0},
-    {"name": "engineering-test-engineer", "repo": "alirezarezvani/claude-skills", "path": "engineering/test-engineer", "description": "Comprehensive test strategy and implementation", "category": "testing", "tags": ["testing", "qa", "automation", "coverage"], "stars": 0},
-    {"name": "product-prd-writer", "repo": "alirezarezvani/claude-skills", "path": "product/prd-writer", "description": "Write comprehensive product requirement documents", "category": "product", "tags": ["prd", "requirements", "product", "documentation"], "stars": 0},
-    {"name": "product-user-researcher", "repo": "alirezarezvani/claude-skills", "path": "product/user-researcher", "description": "Conduct user research and synthesize insights", "category": "product", "tags": ["user-research", "interviews", "insights", "personas"], "stars": 0},
-    {"name": "product-roadmap-planner", "repo": "alirezarezvani/claude-skills", "path": "product/roadmap-planner", "description": "Plan and prioritize product roadmaps", "category": "product", "tags": ["roadmap", "planning", "prioritization", "strategy"], "stars": 0},
-    {"name": "product-metrics-analyst", "repo": "alirezarezvani/claude-skills", "path": "product/metrics-analyst", "description": "Define and analyze product metrics and KPIs", "category": "product", "tags": ["metrics", "analytics", "kpis", "data"], "stars": 0},
-    {"name": "product-feature-specifier", "repo": "alirezarezvani/claude-skills", "path": "product/feature-specifier", "description": "Write detailed feature specifications", "category": "product", "tags": ["features", "specs", "requirements", "user-stories"], "stars": 0},
-    {"name": "design-ui-designer", "repo": "alirezarezvani/claude-skills", "path": "design/ui-designer", "description": "Create intuitive user interface designs", "category": "design", "tags": ["ui", "design", "interface", "visual"], "stars": 0},
-    {"name": "design-ux-researcher", "repo": "alirezarezvani/claude-skills", "path": "design/ux-researcher", "description": "UX research and usability testing", "category": "design", "tags": ["ux", "research", "usability", "testing"], "stars": 0},
-    {"name": "design-system-creator", "repo": "alirezarezvani/claude-skills", "path": "design/system-creator", "description": "Build comprehensive design systems", "category": "design", "tags": ["design-system", "components", "tokens", "guidelines"], "stars": 0},
-    {"name": "design-accessibility-expert", "repo": "alirezarezvani/claude-skills", "path": "design/accessibility-expert", "description": "Ensure designs meet accessibility standards (WCAG)", "category": "design", "tags": ["accessibility", "a11y", "wcag", "inclusive"], "stars": 0},
-    {"name": "design-prototype-builder", "repo": "alirezarezvani/claude-skills", "path": "design/prototype-builder", "description": "Create interactive prototypes and mockups", "category": "design", "tags": ["prototype", "mockup", "interactive", "figma"], "stars": 0},
-    {"name": "data-analyst", "repo": "alirezarezvani/claude-skills", "path": "data/analyst", "description": "Analyze data and generate insights", "category": "data", "tags": ["data", "analysis", "insights", "visualization"], "stars": 0},
-    {"name": "data-pipeline-builder", "repo": "alirezarezvani/claude-skills", "path": "data/pipeline-builder", "description": "Build ETL pipelines and data workflows", "category": "data", "tags": ["etl", "pipeline", "data-engineering", "workflow"], "stars": 0},
-    {"name": "data-visualization-expert", "repo": "alirezarezvani/claude-skills", "path": "data/visualization-expert", "description": "Create compelling data visualizations", "category": "data", "tags": ["visualization", "charts", "dashboards", "d3"], "stars": 0},
-    {"name": "data-ml-engineer", "repo": "alirezarezvani/claude-skills", "path": "data/ml-engineer", "description": "Machine learning model development and deployment", "category": "data", "tags": ["ml", "machine-learning", "models", "training"], "stars": 0},
-    {"name": "data-sql-expert", "repo": "alirezarezvani/claude-skills", "path": "data/sql-expert", "description": "Write optimized SQL queries and database operations", "category": "data", "tags": ["sql", "database", "queries", "optimization"], "stars": 0},
-    {"name": "awesome-claude-skills", "repo": "travisvn/awesome-claude-skills", "path": "", "description": "A curated list of awesome Claude Skills, resources, and tools", "category": "productivity", "tags": ["awesome", "list", "curated", "resources"], "stars": 0}
+    {
+      "name": "superpowers",
+      "repo": "obra/superpowers",
+      "path": "",
+      "description": "20+ battle-tested skills for Claude Code including TDD, debugging, and collaboration patterns",
+      "category": "development",
+      "tags": [
+        "tdd",
+        "debugging",
+        "collaboration",
+        "productivity"
+      ],
+      "stars": 0,
+      "featured": true
+    },
+    {
+      "name": "test-driven-development",
+      "repo": "obra/superpowers",
+      "path": "test-driven-development",
+      "description": "TDD discipline with RED-GREEN-REFACTOR cycle. Ensures tests genuinely verify behavior",
+      "category": "testing",
+      "tags": [
+        "tdd",
+        "testing",
+        "red-green-refactor"
+      ],
+      "stars": 0,
+      "featured": true
+    },
+    {
+      "name": "systematic-debugging",
+      "repo": "obra/superpowers",
+      "path": "systematic-debugging",
+      "description": "Four-phase debugging framework for any technical issue. Prevents random fix attempts",
+      "category": "development",
+      "tags": [
+        "debugging",
+        "troubleshooting",
+        "methodology"
+      ],
+      "stars": 0,
+      "featured": true
+    },
+    {
+      "name": "brainstorming",
+      "repo": "obra/superpowers",
+      "path": "brainstorming",
+      "description": "Collaborative design refinement through Socratic dialogue for exploring ideas",
+      "category": "productivity",
+      "tags": [
+        "brainstorming",
+        "design",
+        "collaboration",
+        "ideation"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "writing-plans",
+      "repo": "obra/superpowers",
+      "path": "writing-plans",
+      "description": "Creates detailed implementation plans with bite-sized tasks",
+      "category": "productivity",
+      "tags": [
+        "planning",
+        "documentation",
+        "writing"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "executing-plans",
+      "repo": "obra/superpowers",
+      "path": "executing-plans",
+      "description": "Batch execution with human checkpoints for implementation",
+      "category": "productivity",
+      "tags": [
+        "execution",
+        "workflow",
+        "automation"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "dispatching-parallel-agents",
+      "repo": "obra/superpowers",
+      "path": "dispatching-parallel-agents",
+      "description": "Enables concurrent subagent workflows for parallel processing",
+      "category": "development",
+      "tags": [
+        "subagents",
+        "parallel",
+        "orchestration"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "requesting-code-review",
+      "repo": "obra/superpowers",
+      "path": "requesting-code-review",
+      "description": "Pre-review checklist and validation before code review",
+      "category": "development",
+      "tags": [
+        "code-review",
+        "checklist",
+        "validation"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "receiving-code-review",
+      "repo": "obra/superpowers",
+      "path": "receiving-code-review",
+      "description": "Handles feedback incorporation from code reviews",
+      "category": "development",
+      "tags": [
+        "code-review",
+        "feedback",
+        "improvement"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "using-git-worktrees",
+      "repo": "obra/superpowers",
+      "path": "using-git-worktrees",
+      "description": "Manages parallel development branches with git worktrees",
+      "category": "development",
+      "tags": [
+        "git",
+        "worktrees",
+        "branching",
+        "parallel"
+      ],
+      "stars": 0,
+      "featured": true
+    },
+    {
+      "name": "finishing-a-development-branch",
+      "repo": "obra/superpowers",
+      "path": "finishing-a-development-branch",
+      "description": "Merge/PR decision workflow for completing branches",
+      "category": "development",
+      "tags": [
+        "git",
+        "merge",
+        "pr",
+        "workflow"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "subagent-driven-development",
+      "repo": "obra/superpowers",
+      "path": "subagent-driven-development",
+      "description": "Two-stage review process - spec compliance then code quality",
+      "category": "development",
+      "tags": [
+        "subagents",
+        "review",
+        "quality"
+      ],
+      "stars": 0,
+      "featured": true
+    },
+    {
+      "name": "verification-before-completion",
+      "repo": "obra/superpowers",
+      "path": "verification-before-completion",
+      "description": "Confirms fixes are effective before marking complete",
+      "category": "development",
+      "tags": [
+        "verification",
+        "quality",
+        "testing"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "writing-skills",
+      "repo": "obra/superpowers",
+      "path": "writing-skills",
+      "description": "Guidance for creating new Claude Code skills following best practices",
+      "category": "development",
+      "tags": [
+        "skills",
+        "creation",
+        "meta"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "elegant-architecture",
+      "repo": "obra/superpowers",
+      "path": "elegant-architecture",
+      "description": "Clean architecture design with strict 200-line file limits",
+      "category": "development",
+      "tags": [
+        "architecture",
+        "clean-code",
+        "modular"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "comprehensive-testing",
+      "repo": "obra/superpowers",
+      "path": "comprehensive-testing",
+      "description": "Complete testing strategy covering unit, integration, E2E",
+      "category": "testing",
+      "tags": [
+        "testing",
+        "unit-tests",
+        "integration",
+        "e2e"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "ln-100-documents-pipeline",
+      "repo": "levnikolaevich/claude-code-skills",
+      "path": "skills/ln-100-documents-pipeline",
+      "description": "Top orchestrator for complete documentation with Linear MCP",
+      "category": "documents",
+      "tags": [
+        "documentation",
+        "orchestrator",
+        "linear",
+        "agile"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "ln-200-scope-decomposer",
+      "repo": "levnikolaevich/claude-code-skills",
+      "path": "skills/ln-200-scope-decomposer",
+      "description": "Full decomposition orchestrator for Agile planning",
+      "category": "productivity",
+      "tags": [
+        "agile",
+        "planning",
+        "decomposition",
+        "linear"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "ln-210-epic-coordinator",
+      "repo": "levnikolaevich/claude-code-skills",
+      "path": "skills/ln-210-epic-coordinator",
+      "description": "Epic creation and management for Agile workflows",
+      "category": "productivity",
+      "tags": [
+        "agile",
+        "epic",
+        "planning",
+        "linear"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "ln-220-story-coordinator",
+      "repo": "levnikolaevich/claude-code-skills",
+      "path": "skills/ln-220-story-coordinator",
+      "description": "Story operations coordinator for Agile teams",
+      "category": "productivity",
+      "tags": [
+        "agile",
+        "stories",
+        "planning",
+        "linear"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "ln-300-task-coordinator",
+      "repo": "levnikolaevich/claude-code-skills",
+      "path": "skills/ln-300-task-coordinator",
+      "description": "Task decomposition coordinator for development",
+      "category": "productivity",
+      "tags": [
+        "agile",
+        "tasks",
+        "decomposition",
+        "linear"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "ln-400-story-pipeline",
+      "repo": "levnikolaevich/claude-code-skills",
+      "path": "skills/ln-400-story-pipeline",
+      "description": "Complete story workflow orchestrator for Agile",
+      "category": "development",
+      "tags": [
+        "agile",
+        "workflow",
+        "pipeline",
+        "linear"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "ln-500-story-quality-gate",
+      "repo": "levnikolaevich/claude-code-skills",
+      "path": "skills/ln-500-story-quality-gate",
+      "description": "Story quality validation coordinator with gates",
+      "category": "testing",
+      "tags": [
+        "quality",
+        "validation",
+        "gates",
+        "linear"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "ln-501-code-quality-checker",
+      "repo": "levnikolaevich/claude-code-skills",
+      "path": "skills/ln-501-code-quality-checker",
+      "description": "Code quality analysis and linting",
+      "category": "development",
+      "tags": [
+        "quality",
+        "linting",
+        "analysis",
+        "linear"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "ln-620-codebase-auditor",
+      "repo": "levnikolaevich/claude-code-skills",
+      "path": "skills/ln-620-codebase-auditor",
+      "description": "Comprehensive codebase audit coordinator",
+      "category": "development",
+      "tags": [
+        "audit",
+        "codebase",
+        "analysis",
+        "linear"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "ln-621-security-auditor",
+      "repo": "levnikolaevich/claude-code-skills",
+      "path": "skills/ln-621-security-auditor",
+      "description": "Security vulnerability scanning for codebases",
+      "category": "development",
+      "tags": [
+        "security",
+        "audit",
+        "vulnerabilities",
+        "linear"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "ln-630-test-auditor",
+      "repo": "levnikolaevich/claude-code-skills",
+      "path": "skills/ln-630-test-auditor",
+      "description": "Test suite quality coordinator and analysis",
+      "category": "testing",
+      "tags": [
+        "testing",
+        "audit",
+        "quality",
+        "linear"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-backend-development",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/backend-development",
+      "description": "Build robust backend systems with Node.js, Python, Go, Rust",
+      "category": "development",
+      "tags": [
+        "backend",
+        "nodejs",
+        "python",
+        "go",
+        "rust"
+      ],
+      "stars": 0,
+      "featured": true
+    },
+    {
+      "name": "claudekit-frontend-development",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/frontend-development",
+      "description": "React/TypeScript patterns with Suspense, lazy loading, TanStack Router",
+      "category": "development",
+      "tags": [
+        "frontend",
+        "react",
+        "typescript",
+        "tanstack"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-web-frameworks",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/web-frameworks",
+      "description": "Build full-stack apps with Next.js, Turborepo, RemixIcon",
+      "category": "development",
+      "tags": [
+        "nextjs",
+        "turborepo",
+        "monorepo",
+        "fullstack"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-ui-styling",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/ui-styling",
+      "description": "Create accessible UIs with shadcn/ui, Tailwind CSS",
+      "category": "design",
+      "tags": [
+        "shadcn",
+        "tailwind",
+        "ui",
+        "accessibility"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-aesthetic",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/aesthetic",
+      "description": "Create aesthetically beautiful interfaces with visual hierarchy",
+      "category": "design",
+      "tags": [
+        "design",
+        "ui",
+        "aesthetics",
+        "visual"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-chrome-devtools",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/chrome-devtools",
+      "description": "Browser automation with Puppeteer for screenshots, network monitoring",
+      "category": "testing",
+      "tags": [
+        "puppeteer",
+        "automation",
+        "browser",
+        "devtools"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-devops",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/devops",
+      "description": "Deploy on Cloudflare, Docker, GCP with serverless and CI/CD",
+      "category": "development",
+      "tags": [
+        "devops",
+        "cloudflare",
+        "docker",
+        "gcp",
+        "ci-cd"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-databases",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/databases",
+      "description": "MongoDB and PostgreSQL - schema design, queries, migrations",
+      "category": "data",
+      "tags": [
+        "mongodb",
+        "postgresql",
+        "database",
+        "schema"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-mcp-builder",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/mcp-builder",
+      "description": "Build MCP servers in Python (FastMCP) or TypeScript",
+      "category": "development",
+      "tags": [
+        "mcp",
+        "fastmcp",
+        "typescript",
+        "python"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-mcp-management",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/mcp-management",
+      "description": "Manage MCP servers - discover, analyze, execute tools",
+      "category": "development",
+      "tags": [
+        "mcp",
+        "management",
+        "tools",
+        "servers"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-repomix",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/repomix",
+      "description": "Package repositories into single AI-friendly files",
+      "category": "productivity",
+      "tags": [
+        "repomix",
+        "packaging",
+        "ai",
+        "analysis"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-media-processing",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/media-processing",
+      "description": "Process multimedia with FFmpeg and ImageMagick",
+      "category": "productivity",
+      "tags": [
+        "ffmpeg",
+        "imagemagick",
+        "media",
+        "processing"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-docs-seeker",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/docs-seeker",
+      "description": "Intelligent documentation discovery using llms.txt standard",
+      "category": "productivity",
+      "tags": [
+        "documentation",
+        "discovery",
+        "llms-txt"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-code-review",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/code-review",
+      "description": "Review code feedback with verification before claims",
+      "category": "development",
+      "tags": [
+        "code-review",
+        "verification",
+        "quality"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-defense-in-depth",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/debugging/defense-in-depth",
+      "description": "Validate at every data layer with entry validation",
+      "category": "development",
+      "tags": [
+        "debugging",
+        "validation",
+        "security"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-root-cause-tracing",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/debugging/root-cause-tracing",
+      "description": "Trace bugs backward through call stacks to find triggers",
+      "category": "development",
+      "tags": [
+        "debugging",
+        "root-cause",
+        "tracing"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-systematic-debugging",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/debugging/systematic-debugging",
+      "description": "Four-phase framework for root cause investigation",
+      "category": "development",
+      "tags": [
+        "debugging",
+        "systematic",
+        "methodology"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-docx",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/document-skills/docx",
+      "description": "Create and edit Word documents with tracked changes",
+      "category": "documents",
+      "tags": [
+        "docx",
+        "word",
+        "documents"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-pdf",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/document-skills/pdf",
+      "description": "Extract text/tables, create PDFs, merge/split documents",
+      "category": "documents",
+      "tags": [
+        "pdf",
+        "documents",
+        "extraction"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-pptx",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/document-skills/pptx",
+      "description": "Create PowerPoint presentations with layouts and animations",
+      "category": "documents",
+      "tags": [
+        "pptx",
+        "powerpoint",
+        "presentations"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-xlsx",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/document-skills/xlsx",
+      "description": "Build spreadsheets with formulas and financial modeling",
+      "category": "documents",
+      "tags": [
+        "xlsx",
+        "excel",
+        "spreadsheets"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-shopify",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/shopify",
+      "description": "Build Shopify apps and themes with GraphQL/REST APIs",
+      "category": "development",
+      "tags": [
+        "shopify",
+        "ecommerce",
+        "graphql",
+        "liquid"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-collision-zone-thinking",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/problem-solving/collision-zone-thinking",
+      "description": "Force unrelated concepts together to discover emergent properties",
+      "category": "productivity",
+      "tags": [
+        "problem-solving",
+        "creativity",
+        "thinking"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-inversion-exercise",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/problem-solving/inversion-exercise",
+      "description": "Flip core assumptions to reveal hidden constraints",
+      "category": "productivity",
+      "tags": [
+        "problem-solving",
+        "inversion",
+        "thinking"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-meta-pattern-recognition",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/problem-solving/meta-pattern-recognition",
+      "description": "Spot patterns across 3+ domains to extract universal principles",
+      "category": "productivity",
+      "tags": [
+        "problem-solving",
+        "patterns",
+        "thinking"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-sequential-thinking",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/sequential-thinking",
+      "description": "Systematic step-by-step reasoning for complex problems",
+      "category": "productivity",
+      "tags": [
+        "reasoning",
+        "thinking",
+        "systematic"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-skill-creator",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/skill-creator",
+      "description": "Guide for creating effective Claude Code skills",
+      "category": "development",
+      "tags": [
+        "skills",
+        "creation",
+        "meta"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-better-auth",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/better-auth",
+      "description": "TypeScript auth framework with OAuth, 2FA, passkeys, multi-tenancy",
+      "category": "development",
+      "tags": [
+        "auth",
+        "oauth",
+        "2fa",
+        "passkeys"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-google-adk-python",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/google-adk-python",
+      "description": "Google Agent Development Kit for AI agents with multi-agent orchestration",
+      "category": "data",
+      "tags": [
+        "google",
+        "adk",
+        "agents",
+        "ai"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudekit-ai-multimodal",
+      "repo": "mrgoonie/claudekit-skills",
+      "path": "skills/ai-multimodal",
+      "description": "Process multimedia using Google Gemini API - audio, image, video",
+      "category": "data",
+      "tags": [
+        "gemini",
+        "multimodal",
+        "audio",
+        "video"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "n8n-expression-syntax",
+      "repo": "czlonkowski/n8n-skills",
+      "path": "skills/n8n-expression-syntax",
+      "description": "n8n expression syntax with $json, $node, $now, $env variables",
+      "category": "development",
+      "tags": [
+        "n8n",
+        "automation",
+        "expressions",
+        "workflow"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "n8n-mcp-tools-expert",
+      "repo": "czlonkowski/n8n-skills",
+      "path": "skills/n8n-mcp-tools-expert",
+      "description": "n8n-mcp MCP tools, validation profiles, nodeType formats",
+      "category": "development",
+      "tags": [
+        "n8n",
+        "mcp",
+        "automation",
+        "tools"
+      ],
+      "stars": 0,
+      "featured": true
+    },
+    {
+      "name": "n8n-workflow-patterns",
+      "repo": "czlonkowski/n8n-skills",
+      "path": "skills/n8n-workflow-patterns",
+      "description": "5 proven architectural patterns for n8n workflows",
+      "category": "development",
+      "tags": [
+        "n8n",
+        "patterns",
+        "architecture",
+        "workflow"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "n8n-validation-expert",
+      "repo": "czlonkowski/n8n-skills",
+      "path": "skills/n8n-validation-expert",
+      "description": "Interpret validation errors and troubleshoot n8n workflows",
+      "category": "development",
+      "tags": [
+        "n8n",
+        "validation",
+        "troubleshooting"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "n8n-node-configuration",
+      "repo": "czlonkowski/n8n-skills",
+      "path": "skills/n8n-node-configuration",
+      "description": "Operation-aware n8n node configuration guidance",
+      "category": "development",
+      "tags": [
+        "n8n",
+        "configuration",
+        "nodes"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "n8n-code-javascript",
+      "repo": "czlonkowski/n8n-skills",
+      "path": "skills/n8n-code-javascript",
+      "description": "JavaScript coding in n8n Code nodes with data access patterns",
+      "category": "development",
+      "tags": [
+        "n8n",
+        "javascript",
+        "code"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "n8n-code-python",
+      "repo": "czlonkowski/n8n-skills",
+      "path": "skills/n8n-code-python",
+      "description": "Python coding in n8n Code nodes with standard library usage",
+      "category": "development",
+      "tags": [
+        "n8n",
+        "python",
+        "code"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "ios-simulator-skill",
+      "repo": "conorluddy/ios-simulator-skill",
+      "path": "",
+      "description": "iOS Simulator automation for testing with semantic navigation and Xcode integration",
+      "category": "testing",
+      "tags": [
+        "ios",
+        "simulator",
+        "xcode",
+        "testing",
+        "mobile"
+      ],
+      "stars": 0,
+      "featured": true
+    },
+    {
+      "name": "playwright-skill",
+      "repo": "lackeyjb/playwright-skill",
+      "path": "",
+      "description": "Browser automation with Playwright - Claude writes and executes custom scripts",
+      "category": "testing",
+      "tags": [
+        "playwright",
+        "browser",
+        "automation",
+        "testing"
+      ],
+      "stars": 0,
+      "featured": true
+    },
+    {
+      "name": "claude-d3js-skill",
+      "repo": "chrisvoncsefalvay/claude-d3js-skill",
+      "path": "",
+      "description": "D3.js visualization skill for creating interactive data visualizations",
+      "category": "data",
+      "tags": [
+        "d3",
+        "visualization",
+        "charts",
+        "javascript"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "ffuf-web-fuzzing",
+      "repo": "jthack/ffuf_claude_skill",
+      "path": "",
+      "description": "Web fuzzing with ffuf for security testing - directories, files, subdomains",
+      "category": "development",
+      "tags": [
+        "security",
+        "fuzzing",
+        "ffuf",
+        "pentesting"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "web-asset-generator",
+      "repo": "alonw0/web-asset-generator",
+      "path": "",
+      "description": "Generate favicons, app icons, social media images with WCAG compliance",
+      "category": "design",
+      "tags": [
+        "favicon",
+        "icons",
+        "pwa",
+        "assets"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "codex-skill",
+      "repo": "feiskyer/claude-code-settings",
+      "path": "plugins/codex-skill",
+      "description": "Non-interactive automation mode using OpenAI Codex",
+      "category": "development",
+      "tags": [
+        "codex",
+        "automation",
+        "openai"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "autonomous-skill",
+      "repo": "feiskyer/claude-code-settings",
+      "path": "plugins/autonomous-skill",
+      "description": "Execute complex long-running tasks across multiple sessions",
+      "category": "development",
+      "tags": [
+        "autonomous",
+        "sessions",
+        "long-running"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "nanobanana-skill",
+      "repo": "feiskyer/claude-code-settings",
+      "path": "plugins/nanobanana-skill",
+      "description": "Generate or edit images using Google Gemini API",
+      "category": "design",
+      "tags": [
+        "gemini",
+        "images",
+        "generation"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "youtube-transcribe-skill",
+      "repo": "feiskyer/claude-code-settings",
+      "path": "plugins/youtube-transcribe-skill",
+      "description": "Extract subtitles and transcripts from YouTube videos",
+      "category": "productivity",
+      "tags": [
+        "youtube",
+        "transcription",
+        "subtitles"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "kiro-skill",
+      "repo": "feiskyer/claude-code-settings",
+      "path": "skills/kiro-skill",
+      "description": "Interactive feature development: Requirements -> Design -> Tasks -> Execute",
+      "category": "development",
+      "tags": [
+        "workflow",
+        "feature",
+        "development"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "spec-kit-skill",
+      "repo": "feiskyer/claude-code-settings",
+      "path": "skills/spec-kit-skill",
+      "description": "GitHub Spec-Kit integration for spec-driven development",
+      "category": "development",
+      "tags": [
+        "spec",
+        "driven",
+        "github"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "typo3-documentation",
+      "repo": "netresearch/claude-code-marketplace",
+      "path": "skills/typo3-documentation",
+      "description": "Create TYPO3 extension documentation",
+      "category": "documents",
+      "tags": [
+        "typo3",
+        "documentation",
+        "cms"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "typo3-testing",
+      "repo": "netresearch/claude-code-marketplace",
+      "path": "skills/typo3-testing",
+      "description": "Manage TYPO3 extension tests",
+      "category": "testing",
+      "tags": [
+        "typo3",
+        "testing",
+        "cms"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "typo3-ddev-setup",
+      "repo": "netresearch/claude-code-marketplace",
+      "path": "skills/typo3-ddev-setup",
+      "description": "Automate DDEV environment setup for TYPO3",
+      "category": "development",
+      "tags": [
+        "typo3",
+        "ddev",
+        "environment"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "typo3-extension-upgrade",
+      "repo": "netresearch/claude-code-marketplace",
+      "path": "skills/typo3-extension-upgrade",
+      "description": "Systematic extension upgrades to newer TYPO3 LTS versions",
+      "category": "development",
+      "tags": [
+        "typo3",
+        "upgrade",
+        "lts"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "jira-integration",
+      "repo": "netresearch/claude-code-marketplace",
+      "path": "skills/jira-integration",
+      "description": "Jira API operations, wiki markup, and workflow automation",
+      "category": "productivity",
+      "tags": [
+        "jira",
+        "api",
+        "workflow",
+        "automation"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "git-workflow",
+      "repo": "netresearch/claude-code-marketplace",
+      "path": "skills/git-workflow",
+      "description": "Git branching strategies and Conventional Commits",
+      "category": "development",
+      "tags": [
+        "git",
+        "branching",
+        "conventional-commits"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "github-project",
+      "repo": "netresearch/claude-code-marketplace",
+      "path": "skills/github-project",
+      "description": "GitHub repository setup and platform features",
+      "category": "development",
+      "tags": [
+        "github",
+        "repository",
+        "setup"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "enterprise-readiness",
+      "repo": "netresearch/claude-code-marketplace",
+      "path": "skills/enterprise-readiness",
+      "description": "OpenSSF security assessment and compliance",
+      "category": "development",
+      "tags": [
+        "openssf",
+        "security",
+        "compliance",
+        "enterprise"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "security-audit-php",
+      "repo": "netresearch/claude-code-marketplace",
+      "path": "skills/security-audit",
+      "description": "OWASP security audit patterns for PHP applications",
+      "category": "development",
+      "tags": [
+        "security",
+        "owasp",
+        "php",
+        "audit"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "php-modernization",
+      "repo": "netresearch/claude-code-marketplace",
+      "path": "skills/php-modernization",
+      "description": "PHP 8.x modernization and type safety",
+      "category": "development",
+      "tags": [
+        "php",
+        "modernization",
+        "php8",
+        "types"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "go-development",
+      "repo": "netresearch/claude-code-marketplace",
+      "path": "skills/go-development",
+      "description": "Production-grade Go development patterns",
+      "category": "development",
+      "tags": [
+        "go",
+        "golang",
+        "patterns"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "agents-md-generator",
+      "repo": "netresearch/claude-code-marketplace",
+      "path": "skills/agents-md-generator",
+      "description": "Generate AGENTS.md documentation for repositories",
+      "category": "documents",
+      "tags": [
+        "agents",
+        "documentation",
+        "generator"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "cli-tools-installer",
+      "repo": "netresearch/claude-code-marketplace",
+      "path": "skills/cli-tools",
+      "description": "Auto-install missing CLI tools as needed",
+      "category": "development",
+      "tags": [
+        "cli",
+        "tools",
+        "installer"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "coach-skill",
+      "repo": "netresearch/claude-code-marketplace",
+      "path": "skills/coach",
+      "description": "Self-improving learning system with friction detection",
+      "category": "productivity",
+      "tags": [
+        "learning",
+        "coaching",
+        "improvement"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claude-scientific-skills",
+      "repo": "K-Dense-AI/claude-scientific-skills",
+      "path": "",
+      "description": "125+ scientific skills for bioinformatics, cheminformatics, clinical research, ML",
+      "category": "data",
+      "tags": [
+        "science",
+        "research",
+        "bioinformatics",
+        "ml"
+      ],
+      "stars": 0,
+      "featured": true
+    },
+    {
+      "name": "skill-seekers",
+      "repo": "yusufkaraaslan/Skill_Seekers",
+      "path": "",
+      "description": "Convert docs, repos, PDFs into Claude Skills with conflict detection",
+      "category": "productivity",
+      "tags": [
+        "converter",
+        "skills",
+        "documentation"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claude-mem",
+      "repo": "thedotmack/claude-mem",
+      "path": "",
+      "description": "Session activity capture with AI compression for context injection",
+      "category": "productivity",
+      "tags": [
+        "memory",
+        "context",
+        "sessions"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "agents-orchestration",
+      "repo": "wshobson/agents",
+      "path": "",
+      "description": "Intelligent automation and multi-agent orchestration for Claude Code",
+      "category": "development",
+      "tags": [
+        "agents",
+        "orchestration",
+        "automation"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "coderunner-sandbox",
+      "repo": "instavm/coderunner",
+      "path": "",
+      "description": "Secure local sandbox to run LLM-generated code using Apple containers",
+      "category": "development",
+      "tags": [
+        "sandbox",
+        "security",
+        "apple",
+        "containers"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "ai-research-skills",
+      "repo": "zechenzhangAGI/AI-research-SKILLs",
+      "path": "",
+      "description": "Library of AI research and engineering skills for multiple AI models",
+      "category": "data",
+      "tags": [
+        "ai",
+        "research",
+        "engineering"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claude-codepro",
+      "repo": "maxritter/claude-codepro",
+      "path": "",
+      "description": "Professional dev environment with spec-driven workflow and cross-session memory",
+      "category": "development",
+      "tags": [
+        "professional",
+        "workflow",
+        "memory"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "pg-aiguide",
+      "repo": "timescale/pg-aiguide",
+      "path": "",
+      "description": "MCP server providing PostgreSQL skills and documentation",
+      "category": "data",
+      "tags": [
+        "postgresql",
+        "mcp",
+        "database"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claudepro-directory",
+      "repo": "JSONbored/claudepro-directory",
+      "path": "",
+      "description": "Searchable collection of pre-built configurations and MCP servers",
+      "category": "productivity",
+      "tags": [
+        "directory",
+        "configurations",
+        "mcp"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "outline-driven-development",
+      "repo": "OutlineDriven/outline-driven-development",
+      "path": "",
+      "description": "Beyond specs or vibes - AST analysis and Modern CLI Tools",
+      "category": "development",
+      "tags": [
+        "outline",
+        "ast",
+        "cli"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "rails-dev-skills",
+      "repo": "alec-c4/claude-skills-rails-dev",
+      "path": "",
+      "description": "Ruby on Rails development skills with RSpec testing",
+      "category": "development",
+      "tags": [
+        "rails",
+        "ruby",
+        "rspec"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "developer-kit-java",
+      "repo": "giuseppe-trisciuoglio/developer-kit",
+      "path": "",
+      "description": "Java/Spring Boot patterns starter toolkit for skills and agents",
+      "category": "development",
+      "tags": [
+        "java",
+        "spring-boot",
+        "patterns"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "universal-dev-skills",
+      "repo": "AsiaOstrich/universal-dev-skills",
+      "path": "",
+      "description": "Skills from universal documentation standards for dev best practices",
+      "category": "development",
+      "tags": [
+        "standards",
+        "best-practices",
+        "universal"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "grok-skill",
+      "repo": "mikedemarais/grok-skill",
+      "path": "",
+      "description": "Route Twitter/X prompts to Grok-4 Live Search",
+      "category": "productivity",
+      "tags": [
+        "grok",
+        "twitter",
+        "search"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claude-code-toolbox",
+      "repo": "alex-feel/claude-code-toolbox",
+      "path": "",
+      "description": "Automated environment configuration with cross-platform setup",
+      "category": "development",
+      "tags": [
+        "toolbox",
+        "environment",
+        "configuration"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "continuous-claude",
+      "repo": "parcadei/Continuous-Claude",
+      "path": "",
+      "description": "Toolkit preserving session state using hooks and file-based handoffs",
+      "category": "development",
+      "tags": [
+        "sessions",
+        "state",
+        "handoffs"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "odin-claude-plugin",
+      "repo": "OutlineDriven/odin-claude-plugin",
+      "path": "",
+      "description": "Outline-driven development as a Claude Code plugin",
+      "category": "development",
+      "tags": [
+        "outline",
+        "plugin",
+        "development"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "ubrowser",
+      "repo": "Lulzx/ubrowser",
+      "path": "",
+      "description": "Browser automation optimized for speed and cost efficiency",
+      "category": "testing",
+      "tags": [
+        "browser",
+        "automation",
+        "speed"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claude-code-artifacts",
+      "repo": "alex-feel/claude-code-artifacts-public",
+      "path": "",
+      "description": "Pre-built library with subagents, hooks, commands, system prompts",
+      "category": "development",
+      "tags": [
+        "artifacts",
+        "subagents",
+        "hooks"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "claude-insane-guide",
+      "repo": "ThibautMelen/claude-insane-guide",
+      "path": "",
+      "description": "Comprehensive French-language guide covering Memory, Commands, MCP",
+      "category": "productivity",
+      "tags": [
+        "guide",
+        "french",
+        "tutorial"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "clone-website",
+      "repo": "julianromli/ai-skills",
+      "path": "clone-website",
+      "description": "Clone and recreate website designs with modern frameworks",
+      "category": "development",
+      "tags": [
+        "web",
+        "clone",
+        "frontend",
+        "design"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "frontend-design",
+      "repo": "julianromli/ai-skills",
+      "path": "frontend-design",
+      "description": "Create distinctive, production-grade frontend interfaces",
+      "category": "design",
+      "tags": [
+        "frontend",
+        "ui",
+        "design",
+        "web"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "frontend-ui-animator",
+      "repo": "julianromli/ai-skills",
+      "path": "frontend-ui-animator",
+      "description": "Add smooth animations and transitions to UI components",
+      "category": "design",
+      "tags": [
+        "animation",
+        "ui",
+        "frontend",
+        "motion"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "backend-dev",
+      "repo": "julianromli/ai-skills",
+      "path": "backend-dev",
+      "description": "Backend development best practices and patterns",
+      "category": "development",
+      "tags": [
+        "backend",
+        "api",
+        "server",
+        "database"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "bug-fixer",
+      "repo": "julianromli/ai-skills",
+      "path": "bug-fixer",
+      "description": "Systematic approach to identifying and fixing bugs",
+      "category": "development",
+      "tags": [
+        "debugging",
+        "bugfix",
+        "troubleshooting"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "code-reviewer",
+      "repo": "julianromli/ai-skills",
+      "path": "code-reviewer",
+      "description": "Comprehensive code review with security and performance analysis",
+      "category": "development",
+      "tags": [
+        "code-review",
+        "quality",
+        "security",
+        "best-practices"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "documentation-creator",
+      "repo": "julianromli/ai-skills",
+      "path": "documentation-creator",
+      "description": "Generate comprehensive documentation for codebases",
+      "category": "documents",
+      "tags": [
+        "documentation",
+        "readme",
+        "api-docs",
+        "technical-writing"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "commit-msg",
+      "repo": "julianromli/ai-skills",
+      "path": "commit-msg",
+      "description": "Generate meaningful, conventional commit messages",
+      "category": "development",
+      "tags": [
+        "git",
+        "commits",
+        "conventional-commits"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "file-organizer",
+      "repo": "julianromli/ai-skills",
+      "path": "file-organizer",
+      "description": "Organize and structure project files intelligently",
+      "category": "productivity",
+      "tags": [
+        "organization",
+        "files",
+        "structure",
+        "cleanup"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "perf-optimizer",
+      "repo": "julianromli/ai-skills",
+      "path": "perf-optimizer",
+      "description": "Performance optimization for web applications",
+      "category": "development",
+      "tags": [
+        "performance",
+        "optimization",
+        "speed",
+        "profiling"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "prompter",
+      "repo": "julianromli/ai-skills",
+      "path": "prompter",
+      "description": "Craft effective prompts for AI interactions",
+      "category": "productivity",
+      "tags": [
+        "prompts",
+        "ai",
+        "prompt-engineering"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "refactorer",
+      "repo": "julianromli/ai-skills",
+      "path": "refactorer",
+      "description": "Intelligent code refactoring with safety checks",
+      "category": "development",
+      "tags": [
+        "refactoring",
+        "clean-code",
+        "improvement"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "security-auditor",
+      "repo": "julianromli/ai-skills",
+      "path": "security-auditor",
+      "description": "Security vulnerability scanning and remediation",
+      "category": "development",
+      "tags": [
+        "security",
+        "audit",
+        "vulnerabilities",
+        "owasp"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "unit-tester",
+      "repo": "julianromli/ai-skills",
+      "path": "unit-tester",
+      "description": "Generate comprehensive unit tests for your code",
+      "category": "testing",
+      "tags": [
+        "unit-tests",
+        "testing",
+        "coverage"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "marketing-brand-builder",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "marketing/brand-builder",
+      "description": "Build and develop brand identity and guidelines",
+      "category": "marketing",
+      "tags": [
+        "brand",
+        "marketing",
+        "identity",
+        "guidelines"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "marketing-content-creator",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "marketing/content-creator",
+      "description": "Create engaging marketing content across channels",
+      "category": "marketing",
+      "tags": [
+        "content",
+        "marketing",
+        "copywriting",
+        "social-media"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "marketing-seo-optimizer",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "marketing/seo-optimizer",
+      "description": "Optimize content and websites for search engines",
+      "category": "marketing",
+      "tags": [
+        "seo",
+        "search",
+        "optimization",
+        "keywords"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "marketing-campaign-planner",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "marketing/campaign-planner",
+      "description": "Plan and execute marketing campaigns",
+      "category": "marketing",
+      "tags": [
+        "campaigns",
+        "marketing",
+        "planning",
+        "strategy"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "marketing-analytics-reporter",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "marketing/analytics-reporter",
+      "description": "Analyze marketing performance and create reports",
+      "category": "marketing",
+      "tags": [
+        "analytics",
+        "reports",
+        "metrics",
+        "kpis"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "engineering-code-architect",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "engineering/code-architect",
+      "description": "Design scalable software architecture",
+      "category": "development",
+      "tags": [
+        "architecture",
+        "design",
+        "scalability",
+        "patterns"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "engineering-api-designer",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "engineering/api-designer",
+      "description": "Design RESTful and GraphQL APIs with best practices",
+      "category": "development",
+      "tags": [
+        "api",
+        "rest",
+        "graphql",
+        "design"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "engineering-database-modeler",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "engineering/database-modeler",
+      "description": "Design efficient database schemas and models",
+      "category": "data",
+      "tags": [
+        "database",
+        "schema",
+        "modeling",
+        "sql"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "engineering-devops-assistant",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "engineering/devops-assistant",
+      "description": "CI/CD pipelines, infrastructure, and deployment automation",
+      "category": "development",
+      "tags": [
+        "devops",
+        "ci-cd",
+        "infrastructure",
+        "automation"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "engineering-test-engineer",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "engineering/test-engineer",
+      "description": "Comprehensive test strategy and implementation",
+      "category": "testing",
+      "tags": [
+        "testing",
+        "qa",
+        "automation",
+        "coverage"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "product-prd-writer",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "product/prd-writer",
+      "description": "Write comprehensive product requirement documents",
+      "category": "product",
+      "tags": [
+        "prd",
+        "requirements",
+        "product",
+        "documentation"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "product-user-researcher",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "product/user-researcher",
+      "description": "Conduct user research and synthesize insights",
+      "category": "product",
+      "tags": [
+        "user-research",
+        "interviews",
+        "insights",
+        "personas"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "product-roadmap-planner",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "product/roadmap-planner",
+      "description": "Plan and prioritize product roadmaps",
+      "category": "product",
+      "tags": [
+        "roadmap",
+        "planning",
+        "prioritization",
+        "strategy"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "product-metrics-analyst",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "product/metrics-analyst",
+      "description": "Define and analyze product metrics and KPIs",
+      "category": "product",
+      "tags": [
+        "metrics",
+        "analytics",
+        "kpis",
+        "data"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "product-feature-specifier",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "product/feature-specifier",
+      "description": "Write detailed feature specifications",
+      "category": "product",
+      "tags": [
+        "features",
+        "specs",
+        "requirements",
+        "user-stories"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "design-ui-designer",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "design/ui-designer",
+      "description": "Create intuitive user interface designs",
+      "category": "design",
+      "tags": [
+        "ui",
+        "design",
+        "interface",
+        "visual"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "design-ux-researcher",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "design/ux-researcher",
+      "description": "UX research and usability testing",
+      "category": "design",
+      "tags": [
+        "ux",
+        "research",
+        "usability",
+        "testing"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "design-system-creator",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "design/system-creator",
+      "description": "Build comprehensive design systems",
+      "category": "design",
+      "tags": [
+        "design-system",
+        "components",
+        "tokens",
+        "guidelines"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "design-accessibility-expert",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "design/accessibility-expert",
+      "description": "Ensure designs meet accessibility standards (WCAG)",
+      "category": "design",
+      "tags": [
+        "accessibility",
+        "a11y",
+        "wcag",
+        "inclusive"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "design-prototype-builder",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "design/prototype-builder",
+      "description": "Create interactive prototypes and mockups",
+      "category": "design",
+      "tags": [
+        "prototype",
+        "mockup",
+        "interactive",
+        "figma"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "data-analyst",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "data/analyst",
+      "description": "Analyze data and generate insights",
+      "category": "data",
+      "tags": [
+        "data",
+        "analysis",
+        "insights",
+        "visualization"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "data-pipeline-builder",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "data/pipeline-builder",
+      "description": "Build ETL pipelines and data workflows",
+      "category": "data",
+      "tags": [
+        "etl",
+        "pipeline",
+        "data-engineering",
+        "workflow"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "data-visualization-expert",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "data/visualization-expert",
+      "description": "Create compelling data visualizations",
+      "category": "data",
+      "tags": [
+        "visualization",
+        "charts",
+        "dashboards",
+        "d3"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "data-ml-engineer",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "data/ml-engineer",
+      "description": "Machine learning model development and deployment",
+      "category": "data",
+      "tags": [
+        "ml",
+        "machine-learning",
+        "models",
+        "training"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "data-sql-expert",
+      "repo": "alirezarezvani/claude-skills",
+      "path": "data/sql-expert",
+      "description": "Write optimized SQL queries and database operations",
+      "category": "data",
+      "tags": [
+        "sql",
+        "database",
+        "queries",
+        "optimization"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "awesome-claude-skills",
+      "repo": "travisvn/awesome-claude-skills",
+      "path": "",
+      "description": "A curated list of awesome Claude Skills, resources, and tools",
+      "category": "productivity",
+      "tags": [
+        "awesome",
+        "list",
+        "curated",
+        "resources"
+      ],
+      "stars": 0
+    },
+    {
+      "name": "agentrank",
+      "repo": "superlowburn/agentrank",
+      "path": "site/public/.well-known/skills/agentrank",
+      "description": "Live search across 25,000+ scored MCP servers and agent tools. Gives your AI current tool recommendations instead of relying on stale training data.",
+      "category": "development",
+      "tags": [
+        "mcp",
+        "tools",
+        "discovery",
+        "ai-agents",
+        "search"
+      ],
+      "stars": 0
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Adds the **AgentRank** skill to the community skills registry.

AgentRank gives Claude Code live search across 25,000+ scored MCP servers, agent tools, and AI skills — updated nightly from real GitHub signals. When an AI is recommending tools, its training data is months old. This skill fixes that by querying the live index instead.

**Skill details:**
- **Name**: agentrank
- **Repo**: superlowburn/agentrank
- **Path**: site/public/.well-known/skills/agentrank/SKILL.md
- **Category**: development
- **Tags**: mcp, tools, discovery, ai-agents, search

**What it does:**
- Triggers when users ask for MCP server recommendations, tool comparisons, or capability discovery
- Queries the AgentRank API for ranked, scored results from 25,000+ tools
- Returns scored results based on stars, freshness, issue health, contributors, and dependents