### PR TITLE
Use Node 24 GitHub action majors

### DIFF
--- a/.github/workflows/metadata-compliance.yml
+++ b/.github/workflows/metadata-compliance.yml
@@ -23,19 +23,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install jsonschema
+          pip install jsonschema pyyaml
 
       - name: Build changed files list
         if: github.event_name == 'pull_request' || github.event.inputs.scan_scope != 'full'
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload compliance artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: metadata-compliance
           path: |

--- a/.github/workflows/publish-from-core.yml
+++ b/.github/workflows/publish-from-core.yml
@@ -68,12 +68,12 @@ jobs:
           echo "data_sha=$data_sha" >> "$GITHUB_OUTPUT"
 
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Checkout pinned core
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ steps.refs.outputs.core_repo }}
           ref: ${{ steps.refs.outputs.core_sha }}
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: 1
 
       - name: Checkout pinned data
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ steps.refs.outputs.data_repo }}
           ref: ${{ steps.refs.outputs.data_sha }}


### PR DESCRIPTION
## Summary
- upgrade main-owned workflows to Node 24-compatible action majors
- replace actions/checkout@v4 with @v6
- replace actions/setup-python@v5 with @v6
- replace actions/upload-artifact@v4 with @v7

## Verification
- PyYAML parse of .github/workflows/*.yml