### PR TITLE
Update publish artifact action for Node 24

### DIFF
--- a/.github/workflows/publish-from-core.yml
+++ b/.github/workflows/publish-from-core.yml
@@ -315,7 +315,7 @@ jobs:
 
       - name: Upload publish status
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: publish-status
           path: provenance/publish-status.json


### PR DESCRIPTION
Closes #30

## Summary
- Updates the main publish workflow artifact upload step from `actions/upload-artifact@v4` to `actions/upload-artifact@v7`.
- Leaves the artifact name, path, and missing-file behavior unchanged.

## Validation
- Confirmed latest `actions/upload-artifact` release is `v7.0.1`.
- Confirmed no `upload-artifact@v4` references remain under `.github/workflows`.
- Parsed workflow YAML files successfully.
- Ran `git diff --check`.
