### PR TITLE
Fix publish tracking for ignored skill dirs

### DIFF
--- a/.github/workflows/publish-from-core.yml
+++ b/.github/workflows/publish-from-core.yml
@@ -135,6 +135,7 @@ jobs:
           import hashlib
           import json
           import os
+          import subprocess
           from datetime import datetime, timezone
           from pathlib import Path
           from typing import Any
@@ -233,6 +234,44 @@ jobs:
                   raise ValueError(f"missing positive shard counts: {', '.join(missing)}")
               return f"largest_generated_file_bytes={largest}"
 
+          def validate_skill_mirror() -> str:
+              stats = load_json("docs/stats.json")
+              expected_skills = int(stats.get("archive_skill_md_count_raw", 0) or 0)
+              expected_metadata = int(stats.get("archive_metadata_count_raw", 0) or 0)
+              skill_paths = sorted((root / "skills").rglob("SKILL.md"))
+              metadata_paths = sorted((root / "skills").rglob("metadata.json"))
+              if len(skill_paths) != expected_skills:
+                  raise ValueError(
+                      f"skills/SKILL.md count={len(skill_paths)}, expected {expected_skills}"
+                  )
+              if len(metadata_paths) != expected_metadata:
+                  raise ValueError(
+                      f"skills/metadata.json count={len(metadata_paths)}, expected {expected_metadata}"
+                  )
+              rel_paths = [
+                  str(path.relative_to(root))
+                  for path in [*skill_paths, *metadata_paths]
+              ]
+              check_ignore = subprocess.run(
+                  ["git", "check-ignore", "--stdin"],
+                  input="\n".join(rel_paths) + "\n",
+                  text=True,
+                  capture_output=True,
+                  check=False,
+              )
+              if check_ignore.returncode == 0:
+                  ignored = [line for line in check_ignore.stdout.splitlines() if line]
+                  sample = ", ".join(ignored[:5])
+                  raise ValueError(
+                      f"{len(ignored)} mirrored skill files are ignored by git: {sample}"
+                  )
+              if check_ignore.returncode != 1:
+                  raise ValueError(check_ignore.stderr.strip() or "git check-ignore failed")
+              return (
+                  f"{len(skill_paths)} SKILL.md and {len(metadata_paths)} metadata files "
+                  "match stats and are not ignored"
+              )
+
           def validate_registry() -> str:
               assert_pointer("registry.json", "registry-manifest.json")
               return assert_manifest("registry-manifest.json")
@@ -268,6 +307,7 @@ jobs:
               ),
           )
           check("stats shard summary", validate_stats)
+          check("skills mirror count and gitignore", validate_skill_mirror)
 
           failed = [item for item in checks if item["status"] != "passed"]
           status = {
@@ -330,6 +370,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
 
           git add -A
+          git add -f skills
           if git diff --staged --quiet; then
             echo "No main artifact changes"
             exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,9 @@ coverage.xml
 # Test artifacts
 .pytest_cache/
 .mypy_cache/
+
+# The publish artifact mirrors the data repository under skills/**.
+# Skill names can legitimately collide with generic ignored directories
+# such as build/ or dist/, so never ignore mirrored skill files.
+!/skills/
+!/skills/**


### PR DESCRIPTION
## Summary

- allow the merged `skills/**` mirror to be tracked even when a skill name matches generic ignored directories like `build/` or `dist/`
- force-add the mirrored `skills` tree during publish commits
- add a publish canary check that compares mirrored SKILL/metadata file counts with `docs/stats.json` and fails if any mirrored skill file is ignored by Git

Closes #32.

## Validation

- `git diff --check`
- `python -c ... git check-ignore --stdin ...` confirmed `skills/development/build/SKILL.md` and `skills/other/build/SKILL.md` are not ignored after the `.gitignore` exception
- `rg -n "skills mirror count|git add -f skills|!/skills" .github/workflows/publish-from-core.yml .gitignore` confirmed the workflow and ignore-rule guardrails are present

## Follow-up after merge

Republish from the already pinned refs:

- core: `0e59575f2850a69d2f8ce373f8e2a6e88fc382d6`
- data: `d9b621f4a5d13d413fc4e1cdf6d7d0d4c4c8ba9e`