### PR TITLE
fix(publish): validate dynamic category manifest

### DIFF
--- a/.github/workflows/publish-from-core.yml
+++ b/.github/workflows/publish-from-core.yml
@@ -283,6 +283,27 @@ jobs:
               assert_pointer("registry.json", "registry-manifest.json")
               return assert_manifest("registry-manifest.json")
 
+          def validate_category_manifest() -> str:
+              index = load_json("docs/categories/index.json")
+              categories = index.get("categories")
+              if not isinstance(categories, list) or not categories:
+                  raise ValueError("docs/categories/index.json has no categories")
+              first = categories[0]
+              if not isinstance(first, dict):
+                  raise ValueError("docs/categories/index.json category entry is not an object")
+              manifest = first.get("manifest")
+              if not isinstance(manifest, str) or not manifest.strip():
+                  raise ValueError("docs/categories/index.json category entry missing manifest")
+              manifest_path = Path(manifest)
+              if manifest_path.is_absolute() or ".." in manifest_path.parts:
+                  raise ValueError(f"invalid category manifest path: {manifest}")
+              detail = assert_manifest(
+                  f"docs/{manifest}",
+                  count_key="count",
+                  artifact_base="docs",
+              )
+              return f"{len(categories)} categories indexed; {detail}"
+
           check("provenance refs", validate_provenance)
           check("registry pointer and manifest", validate_registry)
           check(
@@ -305,14 +326,7 @@ jobs:
                       + assert_manifest(f"docs/{name}-index-manifest.json", artifact_base="docs")
                   ),
               )
-          check(
-              "category index and other manifest",
-              lambda: assert_manifest(
-                  "docs/categories/other/manifest.json",
-                  count_key="count",
-                  artifact_base="docs",
-              ),
-          )
+          check("category index and dynamic manifest", validate_category_manifest)
           check("stats shard summary", validate_stats)
           check("skills mirror count and gitignore", validate_skill_mirror)
 

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -156,6 +156,15 @@ def test_sync_data_stages_registry_shard_artifacts():
     assert "git add registry.json registry_summary.json registry-manifest.json registry-shards/" in workflow
 
 
+def test_publish_canary_uses_dynamic_category_manifest():
+    workflow = read_repo_file(".github/workflows/publish-from-core.yml")
+
+    assert "def validate_category_manifest()" in workflow
+    assert 'load_json("docs/categories/index.json")' in workflow
+    assert "category index and dynamic manifest" in workflow
+    assert '"docs/categories/other/manifest.json"' not in workflow
+
+
 def test_sync_data_cleans_ci_archive_leftovers_before_discovery():
     workflow = read_repo_file(".github/workflows/sync-data.yml")
 


### PR DESCRIPTION
## Summary
- read the category manifest path from docs/categories/index.json during publish canary validation
- remove the hardcoded docs/categories/other/manifest.json assumption
- add a workflow contract test that prevents reintroducing the hardcoded other manifest

## Verification
- python -m pytest tests/test_pipeline_contracts.py::test_publish_canary_uses_dynamic_category_manifest -q --override-ini='addopts='
- python -m ruff check tests/test_pipeline_contracts.py
- python - <<'PY' ... yaml.safe_load(.github/workflows/publish-from-core.yml) ... PY
- git diff --check

Note: running the entire tests/test_pipeline_contracts.py file currently hits pre-existing failures for core-only workflows that are not present in this publish artifact checkout.