### PR TITLE
Free runner disk before publish checkout

### DIFF
--- a/.github/workflows/publish-from-core.yml
+++ b/.github/workflows/publish-from-core.yml
@@ -67,6 +67,28 @@ jobs:
           echo "data_repo=$data_repo" >> "$GITHUB_OUTPUT"
           echo "data_sha=$data_sha" >> "$GITHUB_OUTPUT"
 
+      - name: Free runner disk for large publish
+        run: |
+          set -euo pipefail
+          echo "Disk before cleanup:"
+          df -h
+
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /usr/share/swift \
+            /usr/local/.ghcup \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL \
+            /opt/hostedtoolcache/Ruby \
+            /opt/hostedtoolcache/go \
+            /opt/hostedtoolcache/node || true
+
+          docker system prune -af || true
+
+          echo "Disk after cleanup:"
+          df -h
+
       - name: Checkout main
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- closes #47
- frees nonessential GitHub-hosted runner disk before large publish checkouts
- prints disk usage before/after cleanup for diagnostics
- keeps pinned core/data publish behavior unchanged

## Context
Publish run https://github.com/majiayu000/claude-skill-registry/actions/runs/26642058784 failed while checking out the pinned data repo with `No space left on device`.

## Verification
- YAML-only workflow change reviewed locally
- next verification is rerunning publish for core `48e095f5aa2a1a7311f0f7f8d389c175d1126293` and data `d5fe76cf7ef103a13e7780bc2473a52df681b35e`
