### PR TITLE
docs: clarify generated mirror routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Core source-of-truth issues
+    url: https://github.com/majiayu000/claude-skill-registry-core/issues/new/choose
+    about: Use core for pipeline, source intake, schema, search, Pages, and publish orchestration.
+  - name: Archived skill data issues
+    url: https://github.com/majiayu000/claude-skill-registry-data/issues
+    about: Use data for archived skill body or archive metadata problems.

--- a/.github/ISSUE_TEMPLATE/mirror-artifact.yml
+++ b/.github/ISSUE_TEMPLATE/mirror-artifact.yml
@@ -1,0 +1,31 @@
+name: Mirror Artifact Problem
+description: Report a problem that exists only in the generated main repository artifact.
+title: "[Mirror] "
+labels: ["mirror-artifact"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What generated artifact is wrong, missing, stale, or inconsistent?
+    validations:
+      required: true
+  - type: input
+    id: artifact
+    attributes:
+      label: Artifact path or URL
+      placeholder: registry.json, registry-shards/00.json, provenance/merge-source.json
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Include the expected value, observed value, and any relevant `core_sha` or `data_sha`.
+  - type: checkboxes
+    id: routing
+    attributes:
+      label: Routing check
+      options:
+        - label: This is a generated mirror artifact problem, not a core pipeline or archived data request.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- What generated mirror behavior or main-owned configuration changed? -->
+
+## Routing
+
+- [ ] This change is intentionally main-owned.
+- [ ] Core pipeline/source/index/search changes were not made here.
+- [ ] Generated outputs such as `skills/**`, `registry*.json`, `docs/**`, and `registry-shards/**` were not patched by hand.
+
+## Verification
+
+<!-- List the checks run for this main-owned change. -->

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ The largest searchable index of Claude Code skills, aggregated from GitHub and c
 
 **Repo layout note:** `core` owns workflows/pipeline logic, `data` stores `skills/**`, and `main` is generated from `core + data`. See `SCHEME2_SPLIT.md`.
 
+## Generated Mirror Notice
+
+This repository is the merged publish artifact for browsing and compatibility consumers. Source changes for discovery, download, security scanning, index generation, search, Pages, or publish orchestration belong in [`claude-skill-registry-core`](https://github.com/majiayu000/claude-skill-registry-core). Archived skill body and archive metadata issues belong in [`claude-skill-registry-data`](https://github.com/majiayu000/claude-skill-registry-data).
+
+- **Do not submit normal source PRs here** unless the change is explicitly main-owned, such as publish workflow routing or mirror-only repository metadata.
+- **Release status**: this mirror does not cut independent GitHub Releases for daily generated data. Use `provenance/merge-source.json`, `registry_summary.json`, and the generated timestamps to identify the exact `core_sha` and `data_sha` behind an artifact.
+- **Use issues here only for mirror artifact problems**, such as mismatched generated files, broken compatibility paths, or incorrect provenance after publish.
+
 ## Highlights
 
 - **Massive Skill Index** - Deduplicated, high-quality registry (see badge for live count)


### PR DESCRIPTION
## Summary
- Make the generated mirror role explicit in README, including release/provenance status.
- Add a mirror-artifact issue template and route source/data requests to the correct repos.
- Add a PR template that blocks accidental hand edits to generated outputs.
- Add missing repo topics and `mirror-artifact` label in repository settings.

Closes #46.

## Verification
- Parsed `.github/ISSUE_TEMPLATE/*.yml` with PyYAML.
- `git diff --check`
