### PR TITLE
fix: validate final artifact tree after provenance

### DIFF
--- a/.github/workflows/publish-from-core.yml
+++ b/.github/workflows/publish-from-core.yml
@@ -144,6 +144,12 @@ jobs:
           }
           EOF
 
+      - name: Validate final artifact API contract
+        run: |
+          python3 "${{ steps.srcpaths.outputs.core_dir }}/scripts/check_artifact_api.py" \
+            --root "$GITHUB_WORKSPACE" \
+            --docs-dir "$GITHUB_WORKSPACE/docs"
+
       - name: Validate canary artifact and write publish status
         env:
           CORE_REPO: ${{ steps.refs.outputs.core_repo }}


### PR DESCRIPTION
Closes #51.

Companion fix for majiayu000/claude-skill-registry-core#241 and core PR #248.

After writing provenance/merge-source.json, the publish workflow now reruns the pinned core check_artifact_api.py against the final main workspace before the existing canary/status step.

Verification:
- workflow YAML parses successfully
- step-order and command assertions pass
- git diff --check passes
- strict validator fails closed against the current pre-v1 main artifact, confirming the gate is active