### PR TITLE
docs: accept generated skill corrections as intake

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,11 +2,25 @@
 
 <!-- What generated mirror behavior or main-owned configuration changed? -->
 
-## Routing
+## Contribution type
 
 - [ ] This change is intentionally main-owned.
-- [ ] Core pipeline/source/index/search changes were not made here.
-- [ ] Generated outputs such as `skills/**`, `registry*.json`, `docs/**`, and `registry-shards/**` were not patched by hand.
+- [ ] This is a correction to an existing generated `skills/**` entry submitted through the public main-repository intake.
+- [ ] Core pipeline/source/index/search behavior is unchanged.
+
+Generated archive corrections are welcome here, but they are not merged into
+main directly. A maintainer will verify and port an accepted correction to
+[`claude-skill-registry-data`](https://github.com/majiayu000/claude-skill-registry-data),
+preserve contributor attribution with `Co-authored-by`, and republish main from
+pinned core and data commits. You do not need to recreate the same pull request
+in another repository.
+
+Other generated outputs such as `registry*.json`, `docs/**`, and
+`registry-shards/**` should not be patched by hand.
+
+## Archive correction evidence
+
+<!-- For a skills/** correction, link the authoritative source and list the affected paths. -->
 
 ## Verification
 


### PR DESCRIPTION
## Summary

- make the main PR template accept corrections to existing generated `skills/**` entries as public intake
- explain that maintainers port accepted fixes to data with `Co-authored-by` attribution
- keep other generated registry/index outputs out of hand-edited PRs

## Routing

- [x] This change is intentionally main-owned.
- [x] Core pipeline/source/index/search changes were not made here.
- [x] No generated artifact was patched by hand.

## Verification

- `git diff --check`
- template diff inspected from fresh `origin/main`

Companion architecture: majiayu000/claude-skill-registry-core#265
