### PR TITLE
fix: preserve source attribution in publish commits

### DIFF
--- a/.github/workflows/publish-from-core.yml
+++ b/.github/workflows/publish-from-core.yml
@@ -94,6 +94,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Capture previous publish provenance
+        run: |
+          set -euo pipefail
+          test -s provenance/merge-source.json
+          cp provenance/merge-source.json "$RUNNER_TEMP/previous-merge-source.json"
+
       - name: Checkout pinned core
         uses: actions/checkout@v6
         with:
@@ -101,7 +107,8 @@ jobs:
           ref: ${{ steps.refs.outputs.core_sha }}
           token: ${{ secrets.MAIN_REPO_TOKEN != '' && secrets.MAIN_REPO_TOKEN || github.token }}
           path: _sources/core
-          fetch-depth: 1
+          filter: tree:0
+          fetch-depth: 0
 
       - name: Checkout pinned data
         uses: actions/checkout@v6
@@ -110,7 +117,8 @@ jobs:
           ref: ${{ steps.refs.outputs.data_sha }}
           token: ${{ secrets.DATA_REPO_TOKEN != '' && secrets.DATA_REPO_TOKEN || github.token }}
           path: _sources/data
-          fetch-depth: 1
+          filter: tree:0
+          fetch-depth: 0
 
       - name: Move source repos to temp dirs
         id: srcpaths
@@ -123,6 +131,24 @@ jobs:
           rm -rf _sources
           echo "core_dir=$CORE_DIR" >> "$GITHUB_OUTPUT"
           echo "data_dir=$DATA_DIR" >> "$GITHUB_OUTPUT"
+
+      - name: Build validated publish commit message
+        env:
+          CORE_REPO: ${{ steps.refs.outputs.core_repo }}
+          CORE_SHA: ${{ steps.refs.outputs.core_sha }}
+          DATA_REPO: ${{ steps.refs.outputs.data_repo }}
+          DATA_SHA: ${{ steps.refs.outputs.data_sha }}
+        run: |
+          set -euo pipefail
+          python3 "${{ steps.srcpaths.outputs.core_dir }}/scripts/build_publish_commit_message.py" \
+            --previous-provenance "$RUNNER_TEMP/previous-merge-source.json" \
+            --core-repo "$CORE_REPO" \
+            --core-dir "${{ steps.srcpaths.outputs.core_dir }}" \
+            --core-sha "$CORE_SHA" \
+            --data-repo "$DATA_REPO" \
+            --data-dir "${{ steps.srcpaths.outputs.data_dir }}" \
+            --data-sha "$DATA_SHA" \
+            --output "$RUNNER_TEMP/publish-commit-message.txt"
 
       - name: Rebuild main from pinned refs
         run: |
@@ -425,7 +451,8 @@ jobs:
             exit 0
           fi
 
-          git commit -m "chore: publish merged artifact core@${CORE_SHA:0:12} data@${DATA_SHA:0:12}"
+          test -s "$RUNNER_TEMP/publish-commit-message.txt"
+          git commit --file "$RUNNER_TEMP/publish-commit-message.txt"
           for attempt in 1 2 3; do
             if git push; then
               echo "Push succeeded on attempt $attempt"

--- a/docs/attribution-backfills.md
+++ b/docs/attribution-backfills.md
@@ -1,0 +1,20 @@
+# Attribution Backfills
+
+This ledger records contributor credit restored after a generated change had
+already been published without its source `Co-authored-by` trailer. The normal
+publish workflow now derives validated trailers from the pinned core and data
+commit ranges; entries here are only for pre-automation history and must link
+the original contribution, authoritative port, and published artifact.
+
+## Lee — DynamoDB on-demand pricing correction
+
+- Contributor: [Lee (`LeeroyHannigan`)](https://github.com/LeeroyHannigan)
+- Original report: [main issue #54](https://github.com/majiayu000/claude-skill-registry/issues/54)
+- Original patch: [main PR #53](https://github.com/majiayu000/claude-skill-registry/pull/53)
+- Authoritative port: [data PR #103](https://github.com/majiayu000/claude-skill-registry-data/pull/103)
+- Attributed data commit: `1884f5ff62faefcbbcd656105660254edf23fa61`
+- First published main commit: `2d82af0b54ec083b2c593042a33b4255aaf1601e`
+
+The data commit preserved `Co-authored-by: Lee <leeroyhannigan@yahoo.ie>`, but
+the old subject-only main publisher dropped the trailer. The main commit that
+introduces this ledger is the non-history-rewriting attribution backfill.


### PR DESCRIPTION
## Summary

- capture the previous provenance tuple before rebuilding the merged artifact
- check out complete commit history with `tree:0` partial-clone filtering
- call the core-owned attribution helper from #270 before mutation
- commit the published artifact with the generated message file instead of a subject-only `-m`
- add the auditable one-time Lee attribution backfill ledger

Depends on majiayu000/claude-skill-registry-core#270 and should merge after that PR.

## Lee backfill

The commit in this PR carries:

```text
Co-authored-by: Lee <leeroyhannigan@yahoo.ie>
```

GitHub already maps that email to `LeeroyHannigan` on all four commits from original PR #53. This is a normal additive main commit; no published history is amended or force-pushed.

## Verification

- workflow YAML parses successfully
- structural assertions confirm old provenance is captured before overwrite
- attribution message generation runs before rebuild/commit
- both pinned checkouts use full commit history with `filter: tree:0`
- the commit step uses `git commit --file "$RUNNER_TEMP/publish-commit-message.txt"`
- `git diff --check`

Refs majiayu000/claude-skill-registry-core#269.
