### PR TITLE
Fix LOG-12: validate all category manifests in publish canary

### DIFF
--- a/.github/workflows/publish-from-core.yml
+++ b/.github/workflows/publish-from-core.yml
@@ -254,7 +254,7 @@ jobs:
               entry_total = sum(int(entry.get("count", 0) or 0) for entry in shards)
               if total is not None and entry_total != int(total):
                   raise ValueError(f"{path} count mismatch: entries={entry_total}, total={total}")
-              for entry in shards[:3]:
+              for entry in shards:
                   shard_path = root / artifact_base / str(entry["path"])
                   if not shard_path.exists():
                       raise ValueError(f"missing shard {entry['path']}")
@@ -342,21 +342,28 @@ jobs:
               categories = index.get("categories")
               if not isinstance(categories, list) or not categories:
                   raise ValueError("docs/categories/index.json has no categories")
-              first = categories[0]
-              if not isinstance(first, dict):
-                  raise ValueError("docs/categories/index.json category entry is not an object")
-              manifest = first.get("manifest")
-              if not isinstance(manifest, str) or not manifest.strip():
-                  raise ValueError("docs/categories/index.json category entry missing manifest")
-              manifest_path = Path(manifest)
-              if manifest_path.is_absolute() or ".." in manifest_path.parts:
-                  raise ValueError(f"invalid category manifest path: {manifest}")
-              detail = assert_manifest(
-                  f"docs/{manifest}",
-                  count_key="count",
-                  artifact_base="docs",
-              )
-              return f"{len(categories)} categories indexed; {detail}"
+              details: list[str] = []
+              for position, entry in enumerate(categories):
+                  if not isinstance(entry, dict):
+                      raise ValueError(
+                          f"docs/categories/index.json category entry[{position}] is not an object"
+                      )
+                  manifest = entry.get("manifest")
+                  if not isinstance(manifest, str) or not manifest.strip():
+                      raise ValueError(
+                          f"docs/categories/index.json category entry[{position}] missing manifest"
+                      )
+                  manifest_path = Path(manifest)
+                  if manifest_path.is_absolute() or ".." in manifest_path.parts:
+                      raise ValueError(f"invalid category manifest path: {manifest}")
+                  details.append(
+                      assert_manifest(
+                          f"docs/{manifest}",
+                          count_key="count",
+                          artifact_base="docs",
+                      )
+                  )
+              return f"{len(categories)} categories indexed; " + "; ".join(details)
 
           check("provenance refs", validate_provenance)
           check("registry pointer and manifest", validate_registry)


### PR DESCRIPTION
## Summary
- Closes the declaration–execution gap in the publish canary (`validate_category_manifest`): it now iterates **every** `docs/categories/index.json` entry with the same path-safety checks, instead of only `categories[0]`.
- `assert_manifest` now verifies **all** shard/part files (existence, bytes, sha256), not just `shards[:3]`.
- Fixes #59 (LOG-12).

## Test plan
- [x] Extracted helpers and ran against live `docs/categories` — all 40 categories pass
- [x] Confirmed `categories/development/manifest.json` has 4 parts and all are checked
- [x] Negative: broken non-first category manifest fails validation
- [x] Negative: corrupted `part-003` sha256 fails; old `shards[:3]` would miss it
- [ ] Workflow YAML still parses / canary step remains main-owned only


Made with [Cursor](https://cursor.com)